### PR TITLE
add-to-project workflow: make labels configurable as inputs

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -8,7 +8,11 @@ on:
     types:
       - labeled
   workflow_call:
-
+    inputs:
+      labeled:
+        required: false
+        default: bug, ci, dependencies, documentation, feature, refactor, security, customer
+        type: string
 jobs:
   add-to-project:
     name: Add issue/PR to SynchroHub platform project
@@ -20,4 +24,4 @@ jobs:
           # to the issue
           project-url: ${{ secrets.PLATFORM_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: bug, ci, dependencies, documentation, feature, refactor, security, customer
+          labeled: ${{ inputs.labeled }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- add-to-project workflow: make labels configurable as inputs (PR #27 by
+  @chicco785)
 - Markdown workflow: use customized prettier action (PR #19 by @chicco785)
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-08-22
+## 0.0.2-dev - 2023-08-31
 
 ### Features
 


### PR DESCRIPTION
## Description

Make labels configurable as inputs in add-to-project workflow

## Changes Made

* add input field for labels and set default value as the current static value

## Related Issues

Fixes #25

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.