### PR TITLE
add-to-project workflow: make project url configurable as input parameter 

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -25,6 +25,6 @@ jobs:
         with:
           # You can target a project in a different organization
           # to the issue
-          project-url: ${{ inputs.project-url != "" && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
+          project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ${{ inputs.labeled }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -13,15 +13,18 @@ on:
         required: false
         default: bug, ci, dependencies, documentation, feature, refactor, security, customer
         type: string
+      project-url:
+        required: false
+        type: string
 jobs:
   add-to-project:
-    name: Add issue/PR to SynchroHub platform project
+    name: Add issue/PR to a project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0
         with:
           # You can target a project in a different organization
           # to the issue
-          project-url: ${{ secrets.PLATFORM_PROJECT_URL }}
+          project-url: ${{ inputs.project-url != "" && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ${{ inputs.labeled }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,11 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-08-31
+## 0.0.2-dev - 2023-09-07
 
 ### Features
 
+- add-to-project workflow: make project url configurable as input parameter (PR
+  #33 by @chicco785)
 - add-to-project workflow: make labels configurable as inputs (PR #27 by
   @chicco785)
 - Markdown workflow: use customized prettier action (PR #19 by @chicco785)


### PR DESCRIPTION
## Description

add-to-project workflow: make project url configurable as input parameter 

## Changes Made

add-to-project workflow: make project url configurable as input parameter 

## Related Issues

Fixes #32 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
