### PR TITLE
Release-notes wf: fix default configuration to include only current PR among open PRs

### DIFF
--- a/.github/config/release-config.json
+++ b/.github/config/release-config.json
@@ -13,8 +13,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       },
       {
         "title": "## Bug Fixes",
@@ -29,8 +29,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       },
       {
         "title": "## Continuous Integration",
@@ -45,8 +45,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       },
       {
         "title": "## Security",
@@ -61,8 +61,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       },
       {
         "title": "## Documentation",
@@ -77,8 +77,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       },
       {
         "title": "## Dependencies",
@@ -93,8 +93,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       },
       {
         "title": "## Refactoring",
@@ -109,8 +109,8 @@
             "on_property": "status"
           }
         ],
-        "exhaustive": "true",
-        "exhaustive_rules": "false"
+        "exhaustive": true,
+        "exhaustive_rules": false
       }
     ],
     "pr_template": "- ${{TITLE}} (PR #${{NUMBER}} by @${{AUTHOR}})",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,8 +12,8 @@
 
 ### Bug Fixes
 
-- release-note: fix default configuration to include only current PR among open
-  PRs (PR #34 by @chicco785)
+- Release-notes wf: fix default configuration to include only current PR among
+  open PRs (PR #34 by @chicco785)
 - Markdown workflow: support both .md and .MD extension for markdown files (PR
   #24 by @chicco785)
 - Markdown workflow: include a step using a sed script to remove the added `-`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-09-07
+## 0.0.2-dev - 2023-09-13
 
 ### Features
 
@@ -24,11 +24,6 @@
 - use new action for markdown (PR #15 by @chicco785)
 - Add job to clean up artefacts on pr closure (PR #9 by @chicco785)
 - Add workflow to clean-up action cache on PR closure (PR #8 by @chicco785)
-
-### Documentation
-
-- Fake pr 2 (PR #5 by @chicco785)
-- fake pr 1 (PR #4 by @chicco785)
 
 ### Refactoring
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- release-note: fix default configuration to include only current PR among open
+  PRs (PR #34 by @chicco785)
 - Markdown workflow: support both .md and .MD extension for markdown files (PR
   #24 by @chicco785)
 - Markdown workflow: include a step using a sed script to remove the added `-`


### PR DESCRIPTION
## Description

Release-notes wf: fix default configuration to include only current PR among open PRs

## Changes Made

* fix replacing strings with booleans 

## Related Issues

Fixes #26 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.