### PR TITLE
add-to-project workflow: automatically add reviewers without need of CODEOWNERS

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -51,6 +51,19 @@ jobs:
     permissions: write-all
     steps:
      - if: github.event_name == 'pull_request'
+       run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/$OWNER/teams/$TEAM/repos/$OWNER/$REPO \
+            -f permission='push' 
+       env:
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          TEAM: ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }}
+     - if: github.event_name == 'pull_request'
        uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
         repo-token: ${{ secrets.REPO_PAT }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
     types:
       - labeled
+      - ready_for_review
   workflow_call:
     inputs:
       labeled:

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -48,5 +48,5 @@ jobs:
      - name: Add reviewers
        uses: rhs/add-reviewer-gh-action@1.0.6
        with: 
-         reviewers: ${{ inputs.reviewers }}
+         reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || '@zaphiro-technologies/backend-devs' }}
          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -48,6 +48,7 @@ jobs:
   add-reviewer-to-pr:
     name: Assign Reviewer to PR
     runs-on: ubuntu-latest
+    permissions: read-all|write-all
     steps:
      - if: github.event_name == 'pull_request'
        uses: rowi1de/auto-assign-review-teams@v1.1.3

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -17,9 +17,12 @@ on:
       project-url:
         required: false
         type: string
-      reviewers:
+      reviewers-team:
         required: false
-        default: 'zaphiro-technologies/backend-devs'
+        default: '@zaphiro-technologies/backend-devs'
+        type: string
+      reviewers-individuals:
+        required: false
         type: string
 jobs:
   add-to-project:
@@ -47,9 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - if: github.event_name == 'pull_request'
-       uses: hkusu/review-assign-action@v1
+       uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
-         reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || 'zaphiro-technologies/backend-devs' }}
-         github-token: ${{ secrets.GITHUB_TOKEN }}
-         ready-comment: 'Ready for review :ok: <reviewers>'
-         merged-comment: 'It was merged. Thanks for your review :wink: <reviewers>'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || '@zaphiro-technologies/backend-devs' }} # only works for GitHub Organisation/Teams
+        persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
+        include-draft: false # Draft PRs will be skipped (default: false)
+        skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -48,7 +48,7 @@ jobs:
   add-reviewer-to-pr:
     name: Assign Reviewer to PR
     runs-on: ubuntu-latest
-    permissions: read-all|write-all
+    permissions: write-all
     steps:
      - if: github.event_name == 'pull_request'
        uses: rowi1de/auto-assign-review-teams@v1.1.3

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -16,6 +16,10 @@ on:
       project-url:
         required: false
         type: string
+      reviewers:
+        required: false
+        default: zaphiro-technologies/backend-devs
+        type: string
 jobs:
   add-to-project:
     name: Add issue/PR to a project
@@ -37,3 +41,11 @@ jobs:
       if: github.event_name == 'pull_request'
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+  add-reviewer-to-pr:
+    name: Add Pull Request Reviewer
+    runs-on: ubuntu-latest
+    steps:
+    - uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+      with: 
+        reviewers: ${{ inputs.reviewers }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -18,7 +18,7 @@ on:
         type: string
       reviewers:
         required: false
-        default: zaphiro-technologies/backend-devs
+        default: '@zaphiro-technologies/backend-devs'
         type: string
 jobs:
   add-to-project:
@@ -45,7 +45,8 @@ jobs:
     name: Add Pull Request Reviewer
     runs-on: ubuntu-latest
     steps:
-    - uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
-      with: 
-        reviewers: ${{ inputs.reviewers }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+     - name: Add reviewers
+       uses: rhs/add-reviewer-gh-action@1.0.6
+       with: 
+         reviewers: ${{ inputs.reviewers }}
+         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -50,13 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - if: github.event_name == 'pull_request'
-       uses: actions/github-script@v6
+       uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.rest.pulls.requestReviewers({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: context.payload.pull_request.number,
-            team_reviewers: ["backend-devs"] # replace this with any team existing in your Github org
-          });
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
+        persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
+        include-draft: false # Draft PRs will be skipped (default: false)
+        skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -50,4 +50,4 @@ jobs:
        uses: hkusu/review-assign-action@v1
        with:
          reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || '@zaphiro-technologies/backend-devs' }}
-         token: ${{ secrets.GITHUB_TOKEN }}
+         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - if: github.event_name == 'pull_request'
-       uses: rhs/add-reviewer-gh-action@1.0.6
-       with: 
+       uses: hkusu/review-assign-action@v1
+       with:
          reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || '@zaphiro-technologies/backend-devs' }}
          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -46,7 +46,7 @@ jobs:
     name: Add Pull Request Reviewer
     runs-on: ubuntu-latest
     steps:
-     - name: Add reviewers
+     - if: github.event_name == 'pull_request'
        uses: rhs/add-reviewer-gh-action@1.0.6
        with: 
          reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || '@zaphiro-technologies/backend-devs' }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -19,7 +19,7 @@ on:
         type: string
       reviewers-team:
         required: false
-        default: '@zaphiro-technologies/backend-devs'
+        default: 'zaphiro-technologies/backend-devs'
         type: string
       reviewers-individuals:
         required: false
@@ -53,7 +53,7 @@ jobs:
        uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || '@zaphiro-technologies/backend-devs' }} # only works for GitHub Organisation/Teams
+        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'zaphiro-technologies/backend-devs' }} # only works for GitHub Organisation/Teams
         persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
         include-draft: false # Draft PRs will be skipped (default: false)
         skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -50,10 +50,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - if: github.event_name == 'pull_request'
-       uses: rowi1de/auto-assign-review-teams@v1.1.3
+       uses: actions/github-script@v6
        with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
-        persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
-        include-draft: false # Draft PRs will be skipped (default: false)
-        skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)
+         script: |
+            const team = 'backend-devs';
+            const token = process.env.GITHUB_TOKEN;
+
+            const response = await github.rest.pulls.addReviewers({
+              pull_id: context.payload.pull_id,
+              team_reviewers: [team],
+              token
+            });
+
+            console.log(response);

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -52,14 +52,11 @@ jobs:
      - if: github.event_name == 'pull_request'
        uses: actions/github-script@v6
        with:
-         script: |
-            const team = 'backend-devs';
-            const token = process.env.GITHUB_TOKEN;
-
-            const response = await github.rest.pulls.addReviewers({
-              pull_id: context.payload.pull_id,
-              team_reviewers: [team],
-              token
-            });
-
-            console.log(response);
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.rest.pulls.requestReviewers({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            team_reviewers: ["backend-devs"] # replace this with any team existing in your Github org
+          });

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -53,7 +53,6 @@ jobs:
      - if: github.event_name == 'pull_request'
        uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
         teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
         persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
         include-draft: false # Draft PRs will be skipped (default: false)

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -43,7 +43,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
   add-reviewer-to-pr:
-    name: Add Pull Request Reviewer
+    name: Assign Reviewer to PR
     runs-on: ubuntu-latest
     steps:
      - if: github.event_name == 'pull_request'
@@ -51,3 +51,5 @@ jobs:
        with:
          reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || '@zaphiro-technologies/backend-devs' }}
          github-token: ${{ secrets.GITHUB_TOKEN }}
+         ready-comment: 'Ready for review :ok: <reviewers>'
+         merged-comment: 'It was merged. Thanks for your review :wink: <reviewers>'

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -19,7 +19,7 @@ on:
         type: string
       reviewers-team:
         required: false
-        default: 'zaphiro-technologies/backend-devs'
+        default: 'backend-devs'
         type: string
       reviewers-individuals:
         required: false
@@ -53,7 +53,7 @@ jobs:
        uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'zaphiro-technologies/backend-devs' }} # only works for GitHub Organisation/Teams
+        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
         persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
         include-draft: false # Draft PRs will be skipped (default: false)
         skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -53,6 +53,7 @@ jobs:
      - if: github.event_name == 'pull_request'
        uses: rowi1de/auto-assign-review-teams@v1.1.3
        with:
+        repo-token: ${{ secrets.REPO_PAT }}
         teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
         persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
         include-draft: false # Draft PRs will be skipped (default: false)

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -19,7 +19,7 @@ on:
         type: string
       reviewers:
         required: false
-        default: '@zaphiro-technologies/backend-devs'
+        default: 'zaphiro-technologies/backend-devs'
         type: string
 jobs:
   add-to-project:
@@ -49,7 +49,7 @@ jobs:
      - if: github.event_name == 'pull_request'
        uses: hkusu/review-assign-action@v1
        with:
-         reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || '@zaphiro-technologies/backend-devs' }}
+         reviewers: ${{ inputs.reviewers != '' && inputs.reviewers || 'zaphiro-technologies/backend-devs' }}
          github-token: ${{ secrets.GITHUB_TOKEN }}
          ready-comment: 'Ready for review :ok: <reviewers>'
          merged-comment: 'It was merged. Thanks for your review :wink: <reviewers>'

--- a/README.MD
+++ b/README.MD
@@ -9,7 +9,7 @@ The repository includes:
   [SynchroHub platform project](https://github.com/orgs/zaphiro-technologies/projects/2)
   or to the project defined by `project-url` input parameter with status `new`.
   When a new PR is added, the PR is assigned to its creator.
-  When a PR is set to ready, reviewers from `reviewers-team` inpute parameter (default value 'backend-devs')
+  When a PR is set to ready, reviewers from `reviewers-team` input parameter (default value 'backend-devs')
  or `reviewers-individuals` (comma separated) are added.
 - [check-pr](.github/workflows/check-pr.yaml) workflow: when a new PR is added
   to a repository or any change occurs to the pr, the pr is validated to be sure

--- a/README.MD
+++ b/README.MD
@@ -8,9 +8,9 @@ The repository includes:
   issue or PR is added to a repository, it is also added - by default - to the
   [SynchroHub platform project](https://github.com/orgs/zaphiro-technologies/projects/2)
   or to the project defined by `project-url` input parameter with status `new`.
-  When a new PR is added, the PR is assigned to its creator.
-  When a PR is set to ready, reviewers from `reviewers-team` input parameter (default value 'backend-devs')
- or `reviewers-individuals` (comma separated) are added.
+  When a new PR is added, the PR is assigned to its creator. When a PR is set to
+  ready, reviewers from `reviewers-team` input parameter (default value
+  'backend-devs') or `reviewers-individuals` (comma separated) are added.
 - [check-pr](.github/workflows/check-pr.yaml) workflow: when a new PR is added
   to a repository or any change occurs to the pr, the pr is validated to be sure
   that labels are valid.

--- a/README.MD
+++ b/README.MD
@@ -9,6 +9,8 @@ The repository includes:
   [SynchroHub platform project](https://github.com/orgs/zaphiro-technologies/projects/2)
   or to the project defined by `project-url` input parameter with status `new`.
   When a new PR is added, the PR is assigned to its creator.
+  When a PR is set to ready, reviewers from `reviewers-team` inpute parameter (default value 'backend-devs')
+ or `reviewers-individuals` (comma separated) are added.
 - [check-pr](.github/workflows/check-pr.yaml) workflow: when a new PR is added
   to a repository or any change occurs to the pr, the pr is validated to be sure
   that labels are valid.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- add-to-project workflow: automatically add reviewers without need of
+  CODEOWNERS (PR #37 by @chicco785)
 - add-to-project workflow: automatically assign pr to its creator (PR #36 by
   @chicco785)
 - add-to-project workflow: make project url configurable as input parameter (PR


### PR DESCRIPTION
## Description

automatically add reviewers without need of CODEOWNERS, reviewers are added if and only if the PR is not in draft mode.

The recommendation is to start the PR in draft mode, and move it to ready only when actually ready for review.

While CODEOWNERS is very powerful, it would require to add such file to all repositories.

## Changes Made

* add specified team as collaborator (default team is `backend-devs`)
* add rowi1de/auto-assign-review-teams@v1.1.3 to add-to-project workflow

## Related Issues

Fixes #38

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [x] I have added appropriate documentation or updated existing documentation.
