### PR TITLE
add-to-project workflow: Fix assignment of reviewers also when PR is still in draft mode

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -69,5 +69,6 @@ jobs:
         repo-token: ${{ secrets.REPO_PAT }}
         teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
         persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
-        include-draft: false # Draft PRs will be skipped (default: false)
+        include-draft: true # Draft PRs will be skipped (default: false)
         skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)
+#test #39

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -40,35 +40,34 @@ jobs:
     name: Assign PR to creator
     runs-on: ubuntu-latest
     steps:
-    - name: Assign PR to creator
-      uses: thomaseizinger/assign-pr-creator-action@v1.0.0
-      if: github.event_name == 'pull_request'
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assign PR to creator
+        uses: thomaseizinger/assign-pr-creator-action@v1.0.0
+        if: github.event_name == 'pull_request'
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   add-reviewer-to-pr:
     name: Assign Reviewer to PR
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-     - if: github.event_name == 'pull_request'
-       run: |
+      - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false }}
+        run: |
           gh api \
             --method PUT \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/$OWNER/teams/$TEAM/repos/$OWNER/$REPO \
             -f permission='push' 
-       env:
+        env:
           GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           TEAM: ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }}
-     - if: github.event_name == 'pull_request'
-       uses: rowi1de/auto-assign-review-teams@v1.1.3
-       with:
-        repo-token: ${{ secrets.REPO_PAT }}
-        teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
-        persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
-        include-draft: true # Draft PRs will be skipped (default: false)
-        skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)
-#test #39
+      - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false }}
+        uses: rowi1de/auto-assign-review-teams@v1.1.3
+        with:
+          repo-token: ${{ secrets.REPO_PAT }}
+          teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
+          persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
+          include-draft: false # Draft PRs will be skipped (default: false)
+          skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,8 +16,8 @@
 
 ### Bug Fixes
 
-- Fix assignment of reviewers also when PR is still in draft mode (PR #40 by
-  @chicco785)
+- add-to-project workflow: Fix assignment of reviewers also when PR is still in
+  draft mode (PR #40 by @chicco785)
 - Release-notes wf: fix default configuration to include only current PR among
   open PRs (PR #34 by @chicco785)
 - Markdown workflow: support both .md and .MD extension for markdown files (PR

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-09-27
+## 0.0.2-dev - 2023-10-03
 
 ### Features
 
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+- Update add-to-project.yaml (PR #40 by @chicco785)
 - Release-notes wf: fix default configuration to include only current PR among
   open PRs (PR #34 by @chicco785)
 - Markdown workflow: support both .md and .MD extension for markdown files (PR

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,8 @@
 
 ### Bug Fixes
 
-- Update add-to-project.yaml (PR #40 by @chicco785)
+- Fix assignment of reviewers also when PR is still in draft mode (PR #40 by
+  @chicco785)
 - Release-notes wf: fix default configuration to include only current PR among
   open PRs (PR #34 by @chicco785)
 - Markdown workflow: support both .md and .MD extension for markdown files (PR


### PR DESCRIPTION
## Description

Check that PR is ready before assigning reviewer.

## Changes Made

Add check on PR readiness.

## Related Issues

Fixes #39 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
