### PR TITLE
add-to-project workflow: add support to assign multiple teams as reviewers (comma separated without space)

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -52,22 +52,26 @@ jobs:
     steps:
       - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false }}
         run: |
-          gh api \
-            --method PUT \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/$OWNER/teams/$TEAM/repos/$OWNER/$REPO \
-            -f permission='push' 
+          IFS=,
+          for TEAM in $TEAMS; 
+            do
+              gh api \
+              --method PUT \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /orgs/$OWNER/teams/$TEAM/repos/$OWNER/$REPO \
+              -f permission='push'
+            done
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          TEAM: ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }}
+          TEAMS: ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs,ops' }}
       - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false }}
         uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
           repo-token: ${{ secrets.REPO_PAT }}
-          teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs' }} # only works for GitHub Organisation/Teams
+          teams:  ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs,ops' }} # only works for GitHub Organisation/Teams
           persons:  ${{ inputs.reviewers-individuals }} # add individual persons here
           include-draft: false # Draft PRs will be skipped (default: false)
           skip-with-manual-reviewers: 1 # Skip this action, if the number of reviwers was already assigned (default: 0)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- add support for assign multiple teams as reviewers (comma separated without
+  space) (PR #42 by @chicco785)
 - add-to-project workflow: automatically add reviewers without need of
   CODEOWNERS (PR #37 by @chicco785)
 - add-to-project workflow: automatically assign pr to its creator (PR #36 by

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- add-to-project workflow: add support for assign multiple teams as reviewers
+- add-to-project workflow: add support to assign multiple teams as reviewers
   (comma separated without space) (PR #42 by @chicco785)
 - add-to-project workflow: automatically add reviewers without need of
   CODEOWNERS (PR #37 by @chicco785)
@@ -14,19 +14,19 @@
   #33 by @chicco785)
 - add-to-project workflow: make labels configurable as inputs (PR #27 by
   @chicco785)
-- Markdown workflow: use customized prettier action (PR #19 by @chicco785)
+- Markdown workflow: use customised prettier action (PR #19 by @chicco785)
 
 ### Bug Fixes
 
 - add-to-project workflow: Fix assignment of reviewers also when PR is still in
   draft mode (PR #40 by @chicco785)
-- Release-notes wf: fix default configuration to include only current PR among
-  open PRs (PR #34 by @chicco785)
-- Markdown workflow: support both .md and .MD extension for markdown files (PR
-  #24 by @chicco785)
-- Markdown workflow: include a step using a sed script to remove the added `-`
+- Release-notes workflow: fix default configuration to include only current PR
+  among open PRs (PR #34 by @chicco785)
+- Markdown workflow: support both `.md` and `.MD` extension for markdown files
+  (PR #24 by @chicco785)
+- Markdown workflow: include a step using a `sed` script to remove the added `-`
   by `stefanzweifel/changelog-updater-action@v1` (PR #20 by @chicco785)
-- Clean up storage workflow: Add jq to artefact clean up script (PR #12 by
+- Clean up storage workflow: Add `jq` to artefact clean up script (PR #12 by
   @chicco785)
 
 ### Continuous Integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,7 @@
 
 ### Features
 
-- markdown workflow: run jobs only when there are changes to markdown related
-  files (PR #52 by @chicco785)
 - Add Docker, Go lang and Docker Clean Up workflows (PR #54 by @cosimomeli)
-- add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
-  to `🔖 Ready` (PR #50 by @chicco785)
 - markdown workflow: run jobs only when there are changes to markdown related
   files (PR #52 by @chicco785)
 - add-to-project workflow: set PR on creation to `🏗 In progress` and when ready

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@
 
 ### Features
 
-- add support for assign multiple teams as reviewers (comma separated without
-  space) (PR #42 by @chicco785)
+- add-to-project workflow: add support for assign multiple teams as reviewers
+  (comma separated without space) (PR #42 by @chicco785)
 - add-to-project workflow: automatically add reviewers without need of
   CODEOWNERS (PR #37 by @chicco785)
 - add-to-project workflow: automatically assign pr to its creator (PR #36 by

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,10 +4,10 @@
 
 ### Features
 
-- add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
-  to `🔖 Ready` (PR #50 by @chicco785)
 - markdown workflow: run jobs only when there are changes to markdown related
   files (PR #52 by @chicco785)
+- add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
+  to `🔖 Ready` (PR #50 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
 - add-to-project workflow: add support to assign multiple teams as reviewers

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,15 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-05
+## 0.0.2-dev - 2023-10-06
 
 ### Features
 
-- add-to-project workflow: add support to assign multiple teams as reviewers
-  (comma separated without space) (PR #42 by @chicco785)
 - add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
   to `🔖 Ready` (PR #50 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
+- add-to-project workflow: add support to assign multiple teams as reviewers
+  (comma separated without space) (PR #42 by @chicco785)
 - add-to-project workflow: automatically add reviewers without need of
   CODEOWNERS (PR #37 by @chicco785)
 - add-to-project workflow: automatically assign pr to its creator (PR #36 by


### PR DESCRIPTION
## Description

Add support for assign multiple teams as reviewers (comma separated without space)

## Changes Made

* Split teams using comma and iterate adding rights

## Related Issues

Fixes #41 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
