### PR TITLE
add-to-project workflow: set PR on creation to `🏗 In progress` and  when ready to `🔖 Ready`

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -30,12 +30,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0
+        id: addItem
         with:
           # You can target a project in a different organization
           # to the issue
           project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ${{ inputs.labeled }}
+      - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == true }}
+        uses: kalgurn/update-project-item-status@main
+        with:
+          project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          item-id: ${{ steps.addItem.outputs.itemId }}
+          status: "🏗 In progress"
+      - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false }}
+        uses: kalgurn/update-project-item-status@main
+        with:
+          project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          item-id: ${{ steps.addItem.outputs.itemId }}
+          status: "🔖 Ready"
   assing-pr-to-creator:
     name: Assign PR to creator
     runs-on: ubuntu-latest

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0
-        id: addItem
+        id: add-project
         with:
           # You can target a project in a different organization
           # to the issue
@@ -38,19 +38,21 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ${{ inputs.labeled }}
       - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == true }}
-        uses: kalgurn/update-project-item-status@main
+        uses: titoportas/update-project-fields@v0.1.0
         with:
           project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          item-id: ${{ steps.addItem.outputs.itemId }}
-          status: "🏗 In progress"
+          item-id: ${{ steps.add-project.outputs.itemId }} # Use the item-id output of the previous step
+          field-keys: Status
+          field-values: 🏗 In progress
       - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false }}
-        uses: kalgurn/update-project-item-status@main
+        uses: titoportas/update-project-fields@v0.1.0
         with:
           project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          item-id: ${{ steps.addItem.outputs.itemId }}
-          status: "🔖 Ready"
+          item-id: ${{ steps.add-project.outputs.itemId }} # Use the item-id output of the previous step
+          field-keys: Status
+          field-values: 🔖 Ready
   assing-pr-to-creator:
     name: Assign PR to creator
     runs-on: ubuntu-latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,8 @@
 
 ### Features
 
-- add-to-project workflow: set PR on creation to `in progress` and on `ready` to
-  `ready` (PR #50 by @chicco785)
+- add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
+  to `🔖 Ready` (PR #50 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
 - add-to-project workflow: automatically add reviewers without need of

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,8 @@
 
 ### Continuous Integration
 
-- set PR in progress or ready depending on status (PR #50 by @chicco785)
+- add-to-project workflow: set PR on creation to `in progress` and on `ready` to
+  `ready` (PR #50 by @chicco785)
 - use new action for markdown (PR #15 by @chicco785)
 - Add job to clean up artefacts on pr closure (PR #9 by @chicco785)
 - Add workflow to clean-up action cache on PR closure (PR #8 by @chicco785)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-04
+## 0.0.2-dev - 2023-10-05
 
 ### Features
 
@@ -31,6 +31,7 @@
 
 ### Continuous Integration
 
+- set PR in progress or ready depending on status (PR #50 by @chicco785)
 - use new action for markdown (PR #15 by @chicco785)
 - Add job to clean up artefacts on pr closure (PR #9 by @chicco785)
 - Add workflow to clean-up action cache on PR closure (PR #8 by @chicco785)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- add-to-project workflow: set PR on creation to `in progress` and on `ready` to
+  `ready` (PR #50 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
 - add-to-project workflow: automatically add reviewers without need of
@@ -31,8 +33,6 @@
 
 ### Continuous Integration
 
-- add-to-project workflow: set PR on creation to `in progress` and on `ready` to
-  `ready` (PR #50 by @chicco785)
 - use new action for markdown (PR #15 by @chicco785)
 - Add job to clean up artefacts on pr closure (PR #9 by @chicco785)
 - Add workflow to clean-up action cache on PR closure (PR #8 by @chicco785)


### PR DESCRIPTION
## Description

set PR in progress or ready depending on status

## Changes Made

add conditional action to set PR in progress or ready depending on status

## Related Issues

Fixes #49 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
