### PR TITLE
markdown workflow: run jobs only when there are changes to markdown related files

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -26,7 +26,28 @@ on:
         required: false
         type: string
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      files-changed: ${{ steps.filter.outputs.markdown }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            markdown:
+              - '*.{md,MD}'
+              - '**/*.{md,MD}'
+              - '.github/config/.markdownlint.json'
+              - '.github/config/.prettierignore'
+              - '.github/config/md-link-config.json'
+              - '.github/config/spellcheck.yml'
+              - '.github/config/wordlist.txt'
+              - '.github/workflows/*.yaml'
   markdown:
+    needs: changes
+    if: ${{ needs.changes.outputs.files-changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Prettify MD files
       uses: zaphiro-technologies/prettier_action@main
       with:
-          prettier_options: --ignore-path .github/config/.prettierignore --prose-wrap always --write **/*.{md,MD}
+          prettier_options: --prose-wrap always --write **/*.{md,MD}
           dry: true
           dry_no_fail: true
     - name: Lint

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Prettify MD files
       uses: zaphiro-technologies/prettier_action@main
       with:
-          prettier_options: --prose-wrap always --write **/*.{md,MD}
+          prettier_options: --ignore-path .github/config/.prettierignore --prose-wrap always --write **/*.{md,MD}
           dry: true
           dry_no_fail: true
     - name: Lint

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,13 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-05
+## 0.0.2-dev - 2023-10-09
 
 ### Features
 
-- markdown wf: run jobs only when there are changes to markdown related files
-  (PR #52 by @chicco785)
 - add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
   to `🔖 Ready` (PR #50 by @chicco785)
+- markdown wf: run jobs only when there are changes to markdown related files
+  (PR #52 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
 - add-to-project workflow: automatically add reviewers without need of

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- markdown wf: run jobs only when there are changes to markdown related files
+  (PR #52 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
 - add-to-project workflow: automatically add reviewers without need of

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-04
+## 0.0.2-dev - 2023-10-05
 
 ### Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,13 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-09
+## 0.0.2-dev - 2023-10-10
 
 ### Features
 
 - add-to-project workflow: set PR on creation to `🏗 In progress` and when ready
   to `🔖 Ready` (PR #50 by @chicco785)
-- markdown wf: run jobs only when there are changes to markdown related files
-  (PR #52 by @chicco785)
+- markdown workflow: run jobs only when there are changes to markdown related
+  files (PR #52 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
 - add-to-project workflow: automatically add reviewers without need of


### PR DESCRIPTION
## Description

markdown wf: run jobs only when there are changes to markdown related files

## Changes Made

* markdown wf: run jobs only when there are changes to markdown related files

## Related Issues

Fixes #51 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
