### PR TITLE
markdown workflow: configure globs via input parameter and remove not working `--ignore-path` for `.github/config/.prettierignore`

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Prettify MD files
       uses: zaphiro-technologies/prettier_action@main
       with:
-          prettier_options: --ignore-path .github/config/.prettierignore --prose-wrap always --write **/*.{md,MD}
+          prettier_options: --prose-wrap always --write **/*.{md,MD}
           dry: true
           dry_no_fail: true
     - name: Lint

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -25,6 +25,14 @@ on:
         default: '.github/config/.markdownlint.json'
         required: false
         type: string
+      md-lint-globs:
+        required: false
+        type: string
+        default: |
+          **/*.md
+          **/*.MD
+          #.github
+          #vendor
 jobs:
   markdown:
     runs-on: ubuntu-latest
@@ -46,20 +54,14 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path }}
-        globs: |
-          **/*.md
-          **/*.MD
+        globs: ${{ inputs.md-lint-globs }}
     - name: Lint
       if: ${{ github.event_name != ' workflow_call' }}
       uses: DavidAnson/markdownlint-cli2-action@v11
       with:
         fix: true
         config: '.github/config/.markdownlint.json'
-        globs: |
-          **/*.md
-          **/*.MD
-          #.github
-          #vendor
+        globs: ${{ inputs.md-lint-globs }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -54,14 +54,14 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path }}
-        globs: ${{ inputs.md-lint-globs }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD}' }}
     - name: Lint
       if: ${{ github.event_name != ' workflow_call' }}
       uses: DavidAnson/markdownlint-cli2-action@v11
       with:
         fix: true
         config: '.github/config/.markdownlint.json'
-        globs: ${{ inputs.md-lint-globs }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD}' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-05
+## 0.0.2-dev - 2023-10-08
 
 ### Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-10-08
+## 0.0.2-dev - 2023-10-09
 
 ### Features
 


### PR DESCRIPTION
## Description

markdown workflow: configure globs via input parameter

## Changes Made

* globs for markdown linter are now configurable via a input parameter.

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
