### PR TITLE
docker workflow: add `pre-build` step

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,9 +37,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run pre-build
+        run: |
+          if test -f "Makefile"; then
+              make ci-pre-build
+          fi
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add pre-build step in docker workflow (PR #57 by @cosimomeli)
+- Add `pre-build` step in docker workflow (PR #57 by @cosimomeli)
 - markdown workflow: add optional spell checker (PR #44 by @chicco785)
 - add-to-project workflow: add support to assign multiple teams as reviewers
   (comma separated without space) (PR #42 by @chicco785)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `pre-build` step in docker workflow (PR #57 by @cosimomeli)
+- docker workflow: add `pre-build` step (PR #57 by @cosimomeli)
 - markdown workflow: add optional spell checker (PR #44 by @chicco785)
 - add-to-project workflow: add support to assign multiple teams as reviewers
   (comma separated without space) (PR #42 by @chicco785)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Add pre-build step in docker workflow (PR #57 by @cosimomeli)
+- markdown workflow: add optional spell checker (PR #44 by @chicco785)
 - add-to-project workflow: add support to assign multiple teams as reviewers
   (comma separated without space) (PR #42 by @chicco785)
 - Add Docker, Golang and Docker Clean Up workflows (PR #54 by @cosimomeli)
@@ -13,7 +15,6 @@
   to `🔖 Ready` (PR #50 by @chicco785)
 - markdown workflow: exclude `vendor` folder from links check (PR #47 by @tejo)
 - markdown workflow: exclude `vendor` folder from checks (PR #46 by @tejo)
-- markdown workflow: add optional spell checker (PR #44 by @chicco785)
 - add-to-project workflow: automatically add reviewers without need of
   CODEOWNERS (PR #37 by @chicco785)
 - add-to-project workflow: automatically assign pr to its creator (PR #36 by


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repository. -->

## Description

Add pre-build step in docker workflow to run the `ci-pre-build` task from Makefile, if the file exists.
This, as example, enables Go builds without vendor folder to download private dependencies before the docker build.

## Changes Made

Add pre-build step in docker workflow

## Related Issues

N/A

## Checklist

<!-- Please check off the following items by putting an "x" in the box: -->

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [x] I have added appropriate documentation or updated existing documentation.
