### PR TITLE
markdown workflow: support correctly `.prettierignore`

### DIFF
--- a/.github/config/.prettierignore
+++ b/.github/config/.prettierignore
@@ -1,1 +1,1 @@
-
+__tests__/test.md

--- a/.github/config/.prettierignore
+++ b/.github/config/.prettierignore
@@ -1,1 +1,1 @@
-__tests__/test.md
+../../__tests__/*.md

--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -12,3 +12,5 @@ untagged
 chicco
 tejo
 cosimomeli
+prettifier
+prettierignore

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -92,7 +92,7 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD},#__tests__/test.md' }}
+        globs: ${{ inputs.md-lint-globs || '**/*.md,**/*.MD,#__tests__/test.md' }}
         separator: ${{ inputs.md-lint-globs && '' || ',' }}
     - name: Commit markdown-lint changes
       run: |

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -92,7 +92,7 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD} #__test__/test.md' }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD}\n#__test__/test.md' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -92,7 +92,7 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD} #__tests__/test.md' }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD} \#__tests__/test.md' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -92,7 +92,7 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD}' }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD} #__test__/test.md' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: Prettify MD files
       uses: zaphiro-technologies/prettier_action@main
       with:
-          prettier_options: --prose-wrap always --write **/*.{md,MD}
+          prettier_options: --prose-wrap always --write **/*.{md,MD} --ignore-path .github/config/.prettierignore  --ignore-path .prettierignore
           dry: true
           dry_no_fail: true
     - name: Lint

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -92,7 +92,7 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD}\n#__test__/test.md' }}
+        globs: ${{ inputs.md-lint-globs || '"**/*.{md,MD}" "#__tests__/test.md"' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -92,7 +92,7 @@ jobs:
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '"**/*.{md,MD}" "#__tests__/test.md"' }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD} #__tests__/test.md' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: Prettify MD files
       uses: zaphiro-technologies/prettier_action@main
       with:
-          prettier_options: --prose-wrap always --write **/*.{md,MD} --ignore-path .github/config/.prettierignore  --ignore-path .prettierignore
+          prettier_options: --prose-wrap always --write **/*.{md,MD} --ignore-path .github/config/.prettierignore
           dry: true
           dry_no_fail: true
     - name: Lint

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -88,11 +88,12 @@ jobs:
           dry: true
           dry_no_fail: true
     - name: Lint
-      uses: DavidAnson/markdownlint-cli2-action@v11
+      uses: DavidAnson/markdownlint-cli2-action@v13
       with:
         fix: true
         config: ${{ inputs.config-lint-path || '.github/config/.markdownlint.json' }}
-        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD} \#__tests__/test.md' }}
+        globs: ${{ inputs.md-lint-globs || '**/*.{md,MD},#__tests__/test.md' }}
+        separator: ${{ inputs.md-lint-globs && '' || ',' }}
     - name: Commit markdown-lint changes
       run: |
         git config --global user.name 'Bot'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-11-23
+## 0.0.2-dev - 2023-11-27
 
 ### Features
 
@@ -30,8 +30,8 @@
 
 ### Bug Fixes
 
-- markdown workflow: support correctly `.prettierignore` (PR #65 by @chicco785)
 - pr-check workflow: pass correctly `input.labels` (PR #67 by @chicco785)
+- markdown workflow: support correctly `.prettierignore` (PR #65 by @chicco785)
 - markdown workflow: fix check to enable/disable spellchecker (PR #55 by
   @chicco785)
 - golang workflow: add shell configuration to enable `pipefail` for benchmark

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-11-17
+## 0.0.2-dev - 2023-11-22
 
 ### Features
 
@@ -30,6 +30,7 @@
 
 ### Bug Fixes
 
+- Support correctly .prettierignore (PR #65 by @chicco785)
 - markdown workflow: fix check to enable/disable spellchecker (PR #55 by
   @chicco785)
 - golang workflow: add shell configuration to enable `pipefail` for benchmark

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,7 +30,7 @@
 
 ### Bug Fixes
 
-- Support correctly .prettierignore (PR #65 by @chicco785)
+- markdown workflow: support correctly `.prettierignore` (PR #65 by @chicco785)
 - markdown workflow: fix check to enable/disable spellchecker (PR #55 by
   @chicco785)
 - golang workflow: add shell configuration to enable `pipefail` for benchmark

--- a/__tests__/test.md
+++ b/__tests__/test.md
@@ -1,0 +1,1 @@
+# This file should be ignored by prettifier so the very lengthy title should not be fixed at all and we all should be happy live after

--- a/__tests__/test.md
+++ b/__tests__/test.md
@@ -1,1 +1,3 @@
-# This file should be ignored by prettifier so the very lengthy title should not be fixed at all and we all should be happy live after
+# This file should be ignored by prettifier
+
+Very lengthy text should not be fixed at all by the prettier and we all should be able to live happily after this.


### PR DESCRIPTION
## Description

Support prettier ignore configuration load from `.github/config/.prettierignore`

## Changes Made

Support prettier ignore configuration load from `.github/config/.prettierignore`

## Related Issues

Fixes #61

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [x] I have added appropriate documentation or updated existing documentation.
