### PR TITLE
Lower annotation pollution on PRs

### DIFF
--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -12,3 +12,4 @@ untagged
 chicco
 tejo
 cosimomeli
+hiimjako

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -100,7 +100,7 @@ jobs:
           base-lcov-file: ${{ hashFiles('./lcov.info') != ''  && './lcov.info' || null }}
           minimum-ratio: 70
           send-summary-comment: true
-          show-annotations: "warning"
+          show-annotations: "error"
       - name: Upload code coverage for ref branch
         if: ${{ ! github.event.pull_request }}
         uses: actions/upload-artifact@v3

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # github-workflows Release Notes
 
-## 0.0.2-dev - 2023-11-17
+## 0.0.2-dev - 2023-11-23
 
 ### Features
 
@@ -47,6 +47,7 @@
 
 ### Continuous Integration
 
+- Lower annotation pollution on PRs (PR #68 by @hiimjako)
 - use new action for markdown (PR #15 by @chicco785)
 - Add job to clean up artefacts on pr closure (PR #9 by @chicco785)
 - Add workflow to clean-up action cache on PR closure (PR #8 by @chicco785)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repository. -->

## Description

I propose to update the annotation for codecoverage to error [docs](https://github.com/barecheck/code-coverage-action#:~:text=made%20in%20PR-,show%2Dannotations,-no), because warning inserts to many annotation making unreadable the PRs

## Changes Made

- Updated `golang.yaml` workflow

## Related Issues

<!-- Please list any related issues or pull requests.
Fixes #{bug number}  - use this specific format or issues won't be correctly linked to the PR
-->

## Checklist

<!-- Please check off the following items by putting an "x" in the box: -->

- [X] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
