### PR TITLE
Use current branch if base_ref not available

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           name: benchmark-result
           github_token: ${{ secrets.REPO_PRIVATE_READ_PAT }}
-          branch: ${{github.base_ref}}
+          branch: ${{ github.base_ref || github.ref_name }}
           if_no_artifact_found: warn
       # Run `github-action-benchmark` action
       - name: Store benchmark result


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repository. -->

## Description

Get the benchmark result artifact from the current branch branch when `github.base_ref` is emtpy, so if the action is not running in a PR get the previous result from the running branch (usually `main`)

## Changes Made

- Change the target branch for artifact retrieval from `base_ref` to `base_ref` or `ref_name`

## Related Issues

Fixes #73 

## Checklist

<!-- Please check off the following items by putting an "x" in the box: -->

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
