### PR TITLE
markdown workflow: run spellcheck only on actually changed *.md files

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -65,6 +65,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          list-files: shell
           filters: |
             markdown:
               - '**/!(*RELEASE_NOTES).(md|MD)'
@@ -131,5 +132,4 @@ jobs:
     - name: Spellcheck
       shell: bash
       run: |
-        ./grammar-check.sh
-
+        ./grammar-check.sh -f ${{ needs.changes.outputs.markdown_files }}

--- a/README.MD
+++ b/README.MD
@@ -139,6 +139,12 @@ To check a single file using the interactive mode, run:
 ./grammar-check.sh -m local -f filename.md
 ```
 
+To check a list of file using the interactive mode, run:
+
+```bash
+./grammar-check.sh -f filename1.md filename2.md
+```
+
 ## References
 
 - [Reusable GitHub Workflows][re-usable-github-workflows]

--- a/__tests__/test.md
+++ b/__tests__/test.md
@@ -3,6 +3,8 @@
 Very lengthy text should not be fixed at all by the prettier, and we all should
 be able to live happily after this.
 
+xxxx
+
 ## Text to be split
 
 The European languages are members of the same family. Their separate existence

--- a/grammar-check.sh
+++ b/grammar-check.sh
@@ -19,6 +19,16 @@ errorMessages=""
 declare -a ignorefiles
 parameters=""
 
+clean_brackets() {
+  if [[ $(uname) == "Darwin" ]]; then
+      # macOS requires an argument for -i to specify the backup file extension
+      sed -E -i '' '/```/,/```/! s/`//g' "$1"
+  else
+      # Linux systems do not require an argument for -i
+      sed -E -i '/```/,/```/! s/`//g' "$1"
+  fi
+}
+
 while getopts m:f:mode:file: flag
 do
     case "${flag}" in
@@ -38,6 +48,9 @@ else
       ;;
     local)
       parameters="-e casing -e colloquialisms -e compounding -e confused_words -e false_friends -e gender_neutrality -e grammar -e misc -e punctuation -e redundancy -e repetitions -e regionalisms -e semantics -e style -e typos"
+      ;;
+    local-non-interactive)
+      parameters="-e casing -e colloquialisms -e compounding -e confused_words -e false_friends -e gender_neutrality -e grammar -e misc -e punctuation -e redundancy -e repetitions -e regionalisms -e semantics -e style -e typos  -p"
       ;;
     *)
       echo "Invalid Mode"
@@ -68,6 +81,7 @@ if [ -z ${file+x} ]; then
             echo "The file $file is too big, it will be split in sub files and checked:"
             csplit -k -n 4 -s -f 'tmp' $line '/##/' '{100}'
             while read tmp; do
+                clean_brackets $tmp
                 npx gramma check -m -p $parameters "$tmp"
                 if [ $? -ne 0 ]; then
                   error=1
@@ -78,11 +92,14 @@ if [ -z ${file+x} ]; then
             done <<<$(find . -name "tmp*" -type f)
             rm -rf tmp*
           else
-            npx gramma check -m -p $parameters "$line"
+            cp $line tmp
+            clean_brackets tmp
+            npx gramma check -m -p $parameters tmp
             if [ $? -ne 0 ]; then
                 error=1
                 errorMessages=$errorMessages"\n - ${file}"
-            fi 
+            fi
+            rm tmp
         fi
     fi
   done <<<$(find . -iname "*.md" -type f)
@@ -95,5 +112,25 @@ if [ -z ${file+x} ]; then
   fi
 else
   echo "Checking a single file"
-  npx gramma check -m $parameters $file
+  echo $file
+  # filesize=$(wc -c $file | awk '{print $1}')
+  # if [[ $filesize -gt 20000 && $file ]]
+  #   then
+  #     echo "The file $file is too big, it will be split in sub files and checked:"
+  #     csplit -k -n 4 -s -f 'tmp' $file '/##/' '{100}'
+  #     while read tmp; do
+  #         clean_brackets $tmp
+  #         npx gramma check -m -p $parameters "$tmp"
+  #     done <<<$(find . -name "tmp*" -type f)
+  #     rm -rf tmp*
+  #   else
+  #     if [ "$mode" != "local" ]; then
+  #       cp $file tmp
+  #       clean_brackets tmp
+  #       npx gramma check -m $parameters tmp
+  #       rm tmp
+  #     else
+  #       npx gramma check -m $parameters $file
+  #     fi
+  # fi
 fi


### PR DESCRIPTION
## Description

markdown workflow: run spellcheck only on actually changed *.md files

## Changes Made

markdown workflow: run spellcheck only on actually changed *.md files

## Related Issues

fixes #90

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [x] I have added appropriate documentation or updated existing documentation.
