### PR TITLE
docker workflow: execute only if the pr actor is not dependabot or labels contains `docker`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ github.actor!= 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
+    if: ${{ github.actor== 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
     steps:
       - run: |
           echo "ok"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,6 +19,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_call:
     inputs:
       image-name:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,6 +55,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: ${{ github.actor!= 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
+    steps:
+      - run: |
+          echo "ok"
   build:
     needs: check
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,9 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_call:
     inputs:
       image-name:
@@ -54,7 +51,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
+    if: ${{ github.actor != 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
     steps:
       - run: |
           echo "ok"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,7 +51,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
+    if: ${{ github.actor != 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || github.event_name == 'push' }}  # ignore the pull request which comes from user depbot.
     steps:
       - run: |
           echo "ok"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ github.actor== 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
+    if: ${{ github.actor == 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
     steps:
       - run: |
           echo "ok"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || github.event_name == 'push' }}  # ignore the pull request which comes from user depbot.
     steps:
       - run: |
-          echo "ok"
+          echo "docker build is required"
   build:
     needs: check
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,7 +49,11 @@ on:
 #   pull-requests: read
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor!= 'dependabot[bot]' || contains(github.event.pull_request.labels.*.name, 'docker') || startsWith(github.ref, 'refs/tags/') }}  # ignore the pull request which comes from user depbot.
   build:
+    needs: check
     runs-on: ubuntu-latest
     env:
       GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -106,7 +106,7 @@ jobs:
       run: |
         git config --global user.name 'Bot'
         git config --global user.email 'bot@zaphiro.ch'
-        git commit -am "Automated markdown-lint fixes" || echo "No changes to commit"
+        git commit -am "Automated markdown-lint fixes [dependabot skip]" || echo "No changes to commit"
         git push
         rm -fr vendor
     # Checks the status of hyperlinks in .md and .MD files in verbose mode (the action is case sensitive and .{MD,md})

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -20,6 +20,11 @@ on:
       - '*'
   pull_request_review:
   pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - edited
+      - synchronize
     branches:
       - main
   workflow_call:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -182,7 +182,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         branch: ${{github.event.pull_request.head.ref}}
-        commit_message: 'docs(release_notes): update RELEASE_NOTES.md'
+        commit_message: 'docs(release_notes): update RELEASE_NOTES.md [dependabot skip]'
         file_pattern: RELEASE_NOTES.md
     - name: Commit updated CHANGELOG
       if: startsWith(github.ref, 'refs/tags/')

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,11 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2024-02-27
+## 0.0.3-dev - 2024-02-29
 
 ### Features
 
+- docker workflow: execute only if the pr actor is not dependabot or labels
+  contains `docker` (PR #99 by @chicco785)
 - markdown workflow: run spellcheck only on actually changed \*.md files (PR #96
   by @chicco785)
 - Support different grammar check modalities (local and online) in the script

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,10 +4,10 @@
 
 ### Features
 
-- docker workflow: execute only if the pr actor is not dependabot or labels
-  contains `docker` (PR #99 by @chicco785)
 - golang workflow: skip code coverage if the actor is dependabot (PR #100 by
   @cosimomeli)
+- docker workflow: execute only if the pr actor is not dependabot or labels
+  contains `docker` (PR #99 by @chicco785)
 - markdown workflow: run spellcheck only on actually changed \*.md files (PR #96
   by @chicco785)
 - Support different grammar check modalities (local and online) in the script


### PR DESCRIPTION
## Description

docker workflow: execute only if the pr actor is not dependabot or labels contains `docker`

## Changes Made

* docker workflow: execute only if the pr actor is not dependabot or labels contains `docker`
* markdown and release note workflow: add [[dependabot skip]](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#allowing-dependabot-to-rebase-and-force-push-over-extra-commits) to comment

## Related Issues

Fixes #98 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
