### PR TITLE
Use registry cache to speed up builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -92,6 +92,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build intermediary image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          platforms: ${{ inputs.platforms }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache,mode=max
+          target: build
+          build-args: |
+            GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
+            GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}
+            GIT_URL=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.source']}}
+            BUILD_DATE=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.created']}}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -101,8 +118,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}-buildcache
-          cache-to: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}-buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache,mode=max
           build-args: |
             GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -92,23 +92,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build intermediary image
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ inputs.docker-context }}
-          file: ${{ inputs.docker-file }}
-          platforms: ${{ inputs.platforms }}
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache,mode=max
-          target: build
-          build-args: |
-            GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
-            GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}
-            GIT_URL=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.source']}}
-            BUILD_DATE=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.created']}}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -116,10 +99,13 @@ jobs:
           file: ${{ inputs.docker-file }}
           platforms: ${{ inputs.platforms }}
           push: true
+          target: build
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache,mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache,scope=build
+          cache-to: |
+            type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}:buildcache,mode=max
           build-args: |
             GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -101,8 +101,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}-buildcache
+          cache-to: type=registry,ref=ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}-buildcache,mode=max
           build-args: |
             GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}


### PR DESCRIPTION
## Description

Use registry cache to speed up builds
cf. https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts

## Changes Made

* Use registry cache to speed up builds
* 
## Related Issues

Fixes #108 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
