### PR TITLE
docker workflow: support submodules initialisation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodule: true
       - name: Run pre-build
         run: |
           if test -f "Makefile"; then

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,7 +55,7 @@ on:
         type: string
         default: ''
         description: Use caching mechanism for a given language
-      initialize-submodules:
+      submodules:
         required: false
         type: boolean
         default: false
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: ${{ inputs.initialize-submodules }}
+          submodules: ${{ inputs.submodules }}
       - name: Run pre-build
         run: |
           if test -f "Makefile"; then

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,7 +55,12 @@ on:
         type: string
         default: ''
         description: Use caching mechanism for a given language
-        
+      initialize-submodules:
+        required: false
+        type: boolean
+        default: false
+        description: True to initialize git submodules
+
 # Permissions needed
 # permissions:
 #   contents: read
@@ -80,7 +85,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: ${{ inputs.initialize-submodules }}
       - name: Run pre-build
         run: |
           if test -f "Makefile"; then

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodule: true
+          submodules: true
       - name: Run pre-build
         run: |
           if test -f "Makefile"; then


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repository. -->

## Description

This ensures that the docker.yml action runs on repos that rely on git submodule.

## Changes Made

We enable setting the checkout `submodules` by introducing an action input `initialize-submodules`.
This was tested successfully on a private repository. 

## Checklist

<!-- Please check off the following items by putting an "x" in the box: -->

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [ ] I have added appropriate documentation or updated existing documentation.
