### PR TITLE
Pass Github Token to Docker build process

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,6 +20,10 @@ concurrency:
 
 on:
   workflow_call:
+    secrets:
+      token:
+        required: false
+        description: Token to be used for submodules or for docker builds
     inputs:
       image-name:
         required: false
@@ -60,10 +64,6 @@ on:
         type: string
         default: ''
         description: True or Recursive to initialize git submodules
-      token:
-        required: false
-        type: string
-        description: Token to be used for submodules or for docker builds
 
 # Permissions needed
 # permissions:
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.submodules }}
-          token: ${{ inputs.submodules != '' && inputs.token || github.token }}
+          token: ${{ inputs.submodules != '' && secrets.token || github.token }}
       - name: Run pre-build
         run: |
           if test -f "Makefile"; then
@@ -169,7 +169,7 @@ jobs:
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}
             GIT_URL=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.source']}}
             BUILD_DATE=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.created']}}
-            GITHUB_TOKEN=${{ inputs.token || github.token }}
+            GITHUB_TOKEN=${{ secrets.token || github.token }}
   vulnerability:
     if: ${{ inputs.vulnerability-scan}}
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -60,6 +60,10 @@ on:
         type: string
         default: ''
         description: True or Recursive to initialize git submodules
+      token:
+        required: false
+        type: string
+        description: Token to be used for submodules or for docker builds
 
 # Permissions needed
 # permissions:
@@ -79,14 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
-    env:
-      GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.submodules }}
-          token: ${{ inputs.submodules != '' && secrets.REPO_PRIVATE_READ_PAT || github.token }}
+          token: ${{ inputs.submodules != '' && inputs.token || github.token }}
       - name: Run pre-build
         run: |
           if test -f "Makefile"; then
@@ -167,7 +169,7 @@ jobs:
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}
             GIT_URL=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.source']}}
             BUILD_DATE=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.created']}}
-            GITHUB_TOKEN=${{ env.GH_ACCESS_TOKEN }}
+            GITHUB_TOKEN=${{ inputs.token || github.token }}
   vulnerability:
     if: ${{ inputs.vulnerability-scan}}
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -167,6 +167,7 @@ jobs:
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}
             GIT_URL=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.source']}}
             BUILD_DATE=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.created']}}
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
   vulnerability:
     if: ${{ inputs.vulnerability-scan}}
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -167,7 +167,7 @@ jobs:
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}
             GIT_URL=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.source']}}
             BUILD_DATE=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.created']}}
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN=${{ env.GH_ACCESS_TOKEN }}
   vulnerability:
     if: ${{ inputs.vulnerability-scan}}
     runs-on: ubuntu-latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,10 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2025-02-06
+## 0.0.3-dev - 2025-02-20
 
 ### Features
 
+- Pass Github Token to Docker build process (PR #157 by @chicco785)
 - docker workflow: support private repository checkout (PR #156 by @chicco785)
 - docker workflow: support submodules initialisation (PR #155 by @gtauzin)
 - Use [linkspector](https://github.com/UmbrellaDocs/linkspector) to check links


### PR DESCRIPTION
## Description

While not ideal, the current fledge-power docker build process relies on github to build plugins from zaphiro's private repositories. So we need a way to pass a token able to clone  zaphiro's private repositories to the docker build.

## Changes Made

- Pass Github Token to Docker build process

## Related Issues

- https://github.com/zaphiro-technologies/fledge-power-demo/pull/19

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on fledge
- [ ] I have added appropriate documentation or updated existing documentation.
