### PR TITLE
docker workflow: updated tags type priority values

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -104,12 +104,12 @@ jobs:
           images: ghcr.io/${{github.repository_owner}}/${{ inputs.image-name || github.event.repository.name }}
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=edge,branch=main
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=edge,branch=main,priority=700
+            type=ref,event=branch,priority=800
+            type=ref,event=pr,priority=800
+            type=semver,pattern={{version}},priority=900
+            type=semver,pattern={{major}}.{{minor}},priority=900
+            type=semver,pattern={{major}},priority=900
       - name: Go Build Cache for Docker
         id: cache-go
         if: ${{ inputs.go-cache || inputs.language-cache == 'go' }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2025-09-10
+## 0.0.3-dev - 2025-09-15
 
 ### Features
 
@@ -44,6 +44,8 @@
 
 ### Bug Fixes
 
+- Updated tags type priority values in docker workflow (PR #201 by
+  @frank-flour24)
 - new-release workflow: resolves issues (PR #195 by @kwitekrac)
 - Run Docker Build after Dependabot merged PR (PR #171 by @cosimomeli)
 - Release notes workflow: fix sbom generation (PR #166 by @chicco785)
@@ -68,12 +70,12 @@
 
 ### Dependencies
 
+- Bump actions/setup-python from 5 to 6 (PR #198 by @dependabot[bot])
 - Bump actions/setup-go from 5 to 6 (PR #200 by @dependabot[bot])
 - Bump aws-actions/configure-aws-credentials from 4 to 5 (PR #197 by
   @dependabot[bot])
 - Bump actions/github-script from 7 to 8 (PR #196 by @dependabot[bot])
 - Bump actions/setup-node from 4 to 5 (PR #199 by @dependabot[bot])
-- Bump actions/setup-python from 5 to 6 (PR #198 by @dependabot[bot])
 - Bump SonarSource/sonarqube-scan-action from 5.3.0 to 5.3.1 (PR #191 by
   @dependabot[bot])
 - Bump actions/checkout from 4 to 5 (PR #189 by @dependabot[bot])

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,8 +44,7 @@
 
 ### Bug Fixes
 
-- Updated tags type priority values in docker workflow (PR #201 by
-  @frank-flour24)
+- docker workflow: updated tags type priority values (PR #201 by @frank-flour24)
 - new-release workflow: resolves issues (PR #195 by @kwitekrac)
 - Run Docker Build after Dependabot merged PR (PR #171 by @cosimomeli)
 - Release notes workflow: fix sbom generation (PR #166 by @chicco785)


### PR DESCRIPTION
## Description

In reverse PRs (main -> branch) the docker build uses the tag main instead of branch, allowing unapproved code to reach main and making the content of main unpredictable. This fix resolves the issue tanks to the updated priorities on tags type, allowing the PR and branch name to be populated and used as tags, instead of the only "main" (that usually had high priority).

## Changes Made

- Added explicit priorities to the tags type in the "docker.yaml" workflow file.
- Raised event=pr priority to '800'
- Raised event=branch priority to '800'

## Related Issues

Fixes #185

## Checklist

- [X] I have used a PR title that is descriptive enough for a release note.
- [X] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [X] I have added appropriate documentation or updated existing documentation.
