### PR TITLE
Replace PAT secrets with github app tokens

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -44,19 +44,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/add-to-project@v1.0.2
         id: add-project
         with:
           # You can target a project in a different organization
           # to the issue
           project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           labeled: ${{ inputs.labeled }}
       - if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == true && steps.add-project.outputs.itemId }}
         uses: titoportas/update-project-fields@v0.1.0
         with:
           project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           item-id: ${{ steps.add-project.outputs.itemId }} # Use the item-id output of the previous step
           field-keys: Status
           field-values: 🏗 In progress
@@ -64,7 +69,7 @@ jobs:
         uses: titoportas/update-project-fields@v0.1.0
         with:
           project-url: ${{ inputs.project-url != '' && inputs.project-url || secrets.PLATFORM_PROJECT_URL }}
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           item-id: ${{ steps.add-project.outputs.itemId }} # Use the item-id output of the previous step
           field-keys: Status
           field-values: 🔖 Ready
@@ -87,7 +92,7 @@ jobs:
               -f permission='push'
             done
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           TEAMS: ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs,ops' }}
@@ -95,7 +100,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request'  &&  github.event.pull_request.draft == false && steps.add-project.outputs.itemId }}
         uses: rowi1de/auto-assign-review-teams@v1.1.3
         with:
-          repo-token: ${{ secrets.REPO_PAT }}
+          repo-token: ${{ steps.generate-token.outputs.token }}
           teams: ${{ inputs.reviewers-team != '' && inputs.reviewers-team || 'backend-devs,ops' }} # only works for GitHub Organisation/Teams
           persons: ${{ inputs.reviewers-individuals }} # add individual persons here
           include-draft: false # Draft PRs will be skipped (default: false)

--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -32,9 +32,14 @@ jobs:
   approve-and-merge:
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - name: Approve & Merge Dependabot PRs
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Add label
           if ! gh label list --repo "$GITHUB_REPOSITORY" --limit 100 | grep -q auto-approved; then

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -37,15 +37,6 @@ on:
         required: false
         type: string
 jobs:
-  # pr-title-lint:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     statuses: write
-  #   steps:
-  #     # see https://www.conventionalcommits.org/en/v1.0.0/
-  #     - uses: aslafy-z/conventional-pr-title-action@v3
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   pr-label-check:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -59,6 +59,11 @@ jobs:
       name: ${{inputs.environment}}
       url: https://argocd.${{env.CLUSTER}}.zaphiro.ch/applications/argocd/platforms?view=tree&resource=kind%3AApplication
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - name: Get image tag from git tag
         if: github.ref_type == 'tag'
         run: |
@@ -94,7 +99,7 @@ jobs:
       - name: Checkout of k8s-deployments
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: ${{github.repository_owner}}/k8s-deployments
           ref: main
       - name: Get repository name from values-platforms.yaml
@@ -145,7 +150,7 @@ jobs:
       - name: Commit & Push changed tag
         uses: actions-js/push@v1.5
         with:
-          github_token: ${{ secrets.REPO_PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           branch: main
           message: "Deploy tag ${{env.IMAGE_TAG}} to ${{github.repository}} on ${{inputs.environment}}"
           directory: kubernetes/${{env.CLUSTER}}

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -92,13 +92,17 @@ jobs:
     if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request }}
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
-      GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}} # Can't commit on detached PR merge commit, so this checkouts the branch
-          token: ${{ secrets.REPO_PAT }}
-      - run: git config --global "url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf" "https://github.com/"
+          token: ${{ steps.generate-token.outputs.token }}
+      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -123,9 +127,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
-      GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
@@ -143,16 +151,16 @@ jobs:
       - name: Set-up git credentials for dvc
         if: ${{ inputs.pull-dvc-datasets }}
         env:
-          GH_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh auth setup-git
           git config --global credential.helper '!/usr/bin/gh auth git-credential'
       - name: Pull DVC Data
         env:
-          GH_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         if: ${{ inputs.pull-dvc-datasets }}
         run: dvc pull
-      - run: git config --global "url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf" "https://github.com/"
+      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -191,7 +199,7 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         with:
           name: cov-result
-          github_token: ${{ secrets.REPO_PRIVATE_READ_PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           branch: ${{github.base_ref}}
           if_no_artifact_found: warn
       - name: Generate Code Coverage report
@@ -219,10 +227,14 @@ jobs:
     if: ${{ needs.changes.outputs.files_changed == 'true' && ! inputs.skip-benchmark}}
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
-      GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
-      - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+      - run: git config --global url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -243,7 +255,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v11
         with:
           name: benchmark-result
-          github_token: ${{ secrets.REPO_PRIVATE_READ_PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           branch: ${{ github.base_ref || github.ref_name }}
           if_no_artifact_found: warn
       # Run `github-action-benchmark` action

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -45,11 +45,15 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
-      GH_ACCESS_TOKEN: ${{ secrets.REPO_PRIVATE_READ_PAT }}
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Fix License Header
@@ -68,7 +72,7 @@ jobs:
           author_name: License Bot
           author_email: bot@zaphiro.ch
           message: "Automatic application of license header"
-      - run: git config --global "url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf" "https://github.com/"
+      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - if: ${{ (! inputs.skip-dependecy || inputs.skip-dependecy == '') && hashFiles('go.mod') != '' }}
         name: Set up Go (Go project)
         uses: actions/setup-go@v6

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -87,9 +87,14 @@ jobs:
     if: ${{ needs.changes.outputs.github_actions_files_changed == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Prettify YAML files
@@ -114,9 +119,14 @@ jobs:
     if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Prettify MD files
@@ -179,7 +189,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.REPO_PAT }}
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@v5

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -32,10 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
       - name: "Validate semver"
         if: ${{ inputs.tag != '' }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -176,7 +176,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Code Scan
         if: ${{ inputs.code-scan }}
-        uses: SonarSource/sonarqube-scan-action@v5.3.1
+        uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -77,10 +77,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ ( github.event_name == 'pull_request' && needs.check_reviews.outputs.reviews == 'APPROVED') || github.event.review.state == 'approved' || startsWith(github.ref, 'refs/tags/') }}
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
       - name: "Get Previous tag"
         id: previoustag

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2025-09-23
+## 0.0.3-dev - 2025-09-29
 
 ### Features
 
@@ -71,6 +71,8 @@
 
 ### Dependencies
 
+- Bump SonarSource/sonarqube-scan-action from 5.3.1 to 6.0.0 (PR #203 by
+  @dependabot[bot])
 - Bump actions/setup-python from 5 to 6 (PR #198 by @dependabot[bot])
 - Bump actions/setup-go from 5 to 6 (PR #200 by @dependabot[bot])
 - Bump aws-actions/configure-aws-credentials from 4 to 5 (PR #197 by
@@ -156,6 +158,7 @@
 
 ### Refactoring
 
+- Replace PAT secrets with github app tokens (PR #204 by @chicco785)
 - Reduce number of wf run when pr are in draft mode (PR #160 by @chicco785)
 
 ## 0.0.2 - 2024-02-09


### PR DESCRIPTION
## Description

This PR replaces different PAT secrets - embedding different authorisations - with github app tokens.

## Changes Made

- Replace `REPO_PAT` used to admin repositories (including access control) and related workflows.
- Replace `REPO_PRIVATE_READ_PAT` used to access other private repositories.
- Replace `ADD_TO_PROJECT_PAT` used to add issues to project.

To achieve the scope, the github app was granted the following authorisations:

Repo permissions:
- Read access to actions, members, metadata, and packages
- Read and write access to administration, code, issues, pull requests, and workflows

Organisation permissions:
- Read and write access to organization projects

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on c37-118 repo
- [ ] I have added appropriate documentation or updated existing documentation.
