### PR TITLE
workflows: use official action to create github app tokens and support additional repositories scoping

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/add-to-project@v1.0.2
         id: add-project
         with:

--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -32,11 +32,11 @@ jobs:
   approve-and-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - name: Approve & Merge Dependabot PRs
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -51,7 +51,7 @@ jobs:
           echo "Fetching open Dependabot PRs older than 3 days..."
 
           # Get PRs by dependabot, filter by age
-          gh pr list --repo "$GITHUB_REPOSITORY" --author app/dependabot --state open --json number,createdAt,title --jq '.[] | select((.createdAt | fromdateiso8601) < (now - 259200))' | jq -c '.' | while read pr; do
+          gh pr list --repo "$GITHUB_REPOSITORY" --author app/dependabot --state open --json number,createdAt,title --jq '.[] | select((.createdAt | fromdateiso8601) < (now - 259200))' | jq -c '.' | while IFS= read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             title=$(echo "$pr" | jq -r '.title')
 

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -59,11 +59,11 @@ jobs:
       name: ${{inputs.environment}}
       url: https://argocd.${{env.CLUSTER}}.zaphiro.ch/applications/argocd/platforms?view=tree&resource=kind%3AApplication
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - name: Get image tag from git tag
         if: github.ref_type == 'tag'
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,10 +20,6 @@ concurrency:
 
 on:
   workflow_call:
-    secrets:
-      token:
-        required: false
-        description: Token to be used for submodules or for docker builds
     inputs:
       image-name:
         required: false
@@ -83,20 +79,37 @@ jobs:
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
+      - name: Prepare repositories list
+        id: prepare
+        run: |
+          repos="${{ inputs.repositories }}"
+          current_repo="${GITHUB_REPOSITORY#*/}"
+
+          # If inputs.repositories is empty, just use current repo
+          if [ -z "$repos" ]; then
+            repos="$current_repo"
+          else
+            repos="$repos,$current_repo"
+          fi
+
+          # Convert CSV to newline-separated list and deduplicate
+          echo "repositories<<EOF" >> $GITHUB_OUTPUT
+          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ inputs.repositories }}
+          repositories: ${{ steps.prepare.outputs.repositories }}
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: ${{ inputs.submodules }}
-          token: ${{ inputs.submodules != '' && secrets.token || github.token }}
+          token: ${{ inputs.submodules != '' && steps.generate-token.outputs.token || github.token }}
       - name: Run pre-build
         env:
-          GH_TOKEN: ${{ secrets.token || steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           if test -f "Makefile"; then
               make ci-pre-build

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -185,7 +185,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           secrets: |
-            "github_token=${{ secrets.token || github.token }}"
+            "github_token=${{ steps.generate-token.outputs.token }}"
           build-args: |
             GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -89,7 +89,9 @@ jobs:
         with:
           submodules: ${{ inputs.submodules }}
           token: ${{ inputs.submodules != '' && secrets.token || github.token }}
-      - run: git config --global "url.https://${{ inputs.submodules != '' && secrets.token || github.token }}@github.com/.insteadOf" "https://github.com/"
+      - run: git config --global "url.https://$GH_TOKEN@github.com/.insteadOf" "https://github.com/"
+        env:
+          GH_TOKEN: ${{ secrets.token || github.token }}
       - name: Run pre-build
         env:
           GH_TOKEN: ${{ secrets.token || github.token }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -65,12 +65,6 @@ on:
         default: ""
         description: True or Recursive to initialize git submodules
 
-# Permissions needed
-# permissions:
-#   contents: read
-#   packages: write
-#   pull-requests: read
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -84,17 +78,20 @@ jobs:
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_SECRET }}
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: ${{ inputs.submodules }}
           token: ${{ inputs.submodules != '' && secrets.token || github.token }}
-      - run: git config --global "url.https://$GH_TOKEN@github.com/.insteadOf" "https://github.com/"
-        env:
-          GH_TOKEN: ${{ secrets.token || github.token }}
+      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Run pre-build
         env:
-          GH_TOKEN: ${{ secrets.token || github.token }}
+          GH_TOKEN: ${{ secrets.token || steps.generate-token.outputs.token }}
         run: |
           if test -f "Makefile"; then
               make ci-pre-build

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -89,6 +89,7 @@ jobs:
         with:
           submodules: ${{ inputs.submodules }}
           token: ${{ inputs.submodules != '' && secrets.token || github.token }}
+      - run: git config --global "url.https://${{ inputs.submodules != '' && secrets.token || github.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Run pre-build
         env:
           GH_TOKEN: ${{ secrets.token || github.token }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -64,6 +64,11 @@ on:
         type: string
         default: ""
         description: True or Recursive to initialize git submodules
+      repositories:
+        required: false
+        type: string
+        default: ""
+        description: Comma or newline-separated list of repositories to grant access to during the docker build.
 
 jobs:
   check:
@@ -83,7 +88,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          owner: ${{ github.repository_owner }}
+          repositories: ${{ inputs.repositories }}
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -88,7 +88,6 @@ jobs:
         with:
           submodules: ${{ inputs.submodules }}
           token: ${{ inputs.submodules != '' && secrets.token || github.token }}
-      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Run pre-build
         env:
           GH_TOKEN: ${{ secrets.token || steps.generate-token.outputs.token }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -78,11 +78,12 @@ jobs:
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -79,29 +79,12 @@ jobs:
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
-      - name: Prepare repositories list
-        id: prepare
-        run: |
-          repos="${{ inputs.repositories }}"
-          current_repo="${GITHUB_REPOSITORY#*/}"
-
-          # If inputs.repositories is empty, just use current repo
-          if [ -z "$repos" ]; then
-            repos="$current_repo"
-          else
-            repos="$repos,$current_repo"
-          fi
-
-          # Convert CSV to newline-separated list and deduplicate
-          echo "repositories<<EOF" >> $GITHUB_OUTPUT
-          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ steps.prepare.outputs.repositories }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -268,12 +268,29 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
+      - name: Prepare repositories list
+        id: prepare
+        run: |
+          repos="${{ inputs.repositories }}"
+          current_repo="${GITHUB_REPOSITORY#*/}"
+
+          # If inputs.repositories is empty, just use current repo
+          if [ -z "$repos" ]; then
+            repos="$current_repo"
+          else
+            repos="$repos,$current_repo"
+          fi
+
+          # Convert CSV to newline-separated list and deduplicate
+          echo "repositories<<EOF" >> $GITHUB_OUTPUT
+          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ inputs.repositories }}
+          repositories: ${{ steps.prepare.outputs.repositories }}
       - uses: actions/checkout@v5
       - run: git config --global url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - uses: actions/setup-go@v6

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -93,16 +93,17 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}} # Can't commit on detached PR merge commit, so this checkouts the branch
           token: ${{ steps.generate-token.outputs.token }}
-      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
+      - run: git config --global "url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -129,11 +130,12 @@ jobs:
       GOPRIVATE: github.com/zaphiro-technologies/*
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
@@ -160,7 +162,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         if: ${{ inputs.pull-dvc-datasets }}
         run: dvc pull
-      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
+      - run: git config --global "url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -228,11 +230,11 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
       - run: git config --global url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - uses: actions/setup-go@v6

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -97,12 +97,29 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
+      - name: Prepare repositories list
+        id: prepare
+        run: |
+          repos="${{ inputs.repositories }}"
+          current_repo="${GITHUB_REPOSITORY#*/}"
+
+          # If inputs.repositories is empty, just use current repo
+          if [ -z "$repos" ]; then
+            repos="$current_repo"
+          else
+            repos="$repos,$current_repo"
+          fi
+
+          # Convert CSV to newline-separated list and deduplicate
+          echo "repositories<<EOF" >> $GITHUB_OUTPUT
+          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ inputs.repositories }}
+          repositories: ${{ steps.prepare.outputs.repositories }}
       - uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}} # Can't commit on detached PR merge commit, so this checkouts the branch
@@ -134,12 +151,29 @@ jobs:
       GOPRIVATE: github.com/zaphiro-technologies/*
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
+      - name: Prepare repositories list
+        id: prepare
+        run: |
+          repos="${{ inputs.repositories }}"
+          current_repo="${GITHUB_REPOSITORY#*/}"
+
+          # If inputs.repositories is empty, just use current repo
+          if [ -z "$repos" ]; then
+            repos="$current_repo"
+          else
+            repos="$repos,$current_repo"
+          fi
+
+          # Convert CSV to newline-separated list and deduplicate
+          echo "repositories<<EOF" >> $GITHUB_OUTPUT
+          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ inputs.repositories }}
+          repositories: ${{ steps.prepare.outputs.repositories }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -97,29 +97,12 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
-      - name: Prepare repositories list
-        id: prepare
-        run: |
-          repos="${{ inputs.repositories }}"
-          current_repo="${GITHUB_REPOSITORY#*/}"
-
-          # If inputs.repositories is empty, just use current repo
-          if [ -z "$repos" ]; then
-            repos="$current_repo"
-          else
-            repos="$repos,$current_repo"
-          fi
-
-          # Convert CSV to newline-separated list and deduplicate
-          echo "repositories<<EOF" >> $GITHUB_OUTPUT
-          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ steps.prepare.outputs.repositories }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
       - uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}} # Can't commit on detached PR merge commit, so this checkouts the branch
@@ -151,29 +134,12 @@ jobs:
       GOPRIVATE: github.com/zaphiro-technologies/*
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
-      - name: Prepare repositories list
-        id: prepare
-        run: |
-          repos="${{ inputs.repositories }}"
-          current_repo="${GITHUB_REPOSITORY#*/}"
-
-          # If inputs.repositories is empty, just use current repo
-          if [ -z "$repos" ]; then
-            repos="$current_repo"
-          else
-            repos="$repos,$current_repo"
-          fi
-
-          # Convert CSV to newline-separated list and deduplicate
-          echo "repositories<<EOF" >> $GITHUB_OUTPUT
-          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ steps.prepare.outputs.repositories }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
@@ -268,29 +234,12 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
-      - name: Prepare repositories list
-        id: prepare
-        run: |
-          repos="${{ inputs.repositories }}"
-          current_repo="${GITHUB_REPOSITORY#*/}"
-
-          # If inputs.repositories is empty, just use current repo
-          if [ -z "$repos" ]; then
-            repos="$current_repo"
-          else
-            repos="$repos,$current_repo"
-          fi
-
-          # Convert CSV to newline-separated list and deduplicate
-          echo "repositories<<EOF" >> $GITHUB_OUTPUT
-          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ steps.prepare.outputs.repositories }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
       - uses: actions/checkout@v5
       - run: git config --global url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - uses: actions/setup-go@v6

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -58,7 +58,11 @@ on:
         default: false
         type: boolean
         description: True to install and configure dvc
-
+      repositories:
+        required: false
+        type: string
+        default: "cim-measurements-go,logging,protobuf"
+        description: Comma or newline-separated list of repositories to grant access to during the golang build.
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -98,7 +102,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          owner: ${{ github.repository_owner }}
+          repositories: ${{ inputs.repositories }}
       - uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.ref}} # Can't commit on detached PR merge commit, so this checkouts the branch
@@ -135,7 +139,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          owner: ${{ github.repository_owner }}
+          repositories: ${{ inputs.repositories }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
@@ -235,8 +239,9 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
+          repositories: ${{ inputs.repositories }}
       - uses: actions/checkout@v5
-      - run: git config --global url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
+      - run: git config --global url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -61,7 +61,7 @@ on:
       repositories:
         required: false
         type: string
-        default: "cim-measurements-go,logging,protobuf"
+        default: ""
         description: Comma or newline-separated list of repositories to grant access to during the golang build.
 jobs:
   changes:

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -46,11 +46,11 @@ jobs:
     env:
       GOPRIVATE: github.com/zaphiro-technologies/*
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -72,7 +72,7 @@ jobs:
           author_name: License Bot
           author_email: bot@zaphiro.ch
           message: "Automatic application of license header"
-      - run: git config --global "url.https://${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
+      - run: git config --global "url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf" "https://github.com/"
       - if: ${{ (! inputs.skip-dependecy || inputs.skip-dependecy == '') && hashFiles('go.mod') != '' }}
         name: Set up Go (Go project)
         uses: actions/setup-go@v6

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -111,6 +111,7 @@ jobs:
           git push
       - uses: reviewdog/action-actionlint@v1
         env:
+          # https://www.shellcheck.net/wiki/
           SHELLCHECK_OPTS: "-e SC2086 -e SC2129"
         with:
           level: warning

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -87,11 +87,11 @@ jobs:
     if: ${{ needs.changes.outputs.github_actions_files_changed == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -119,11 +119,11 @@ jobs:
     if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -110,6 +110,8 @@ jobs:
           git commit -am "Automated yaml-lint fixes [dependabot skip]" || echo "No changes to commit"
           git push
       - uses: reviewdog/action-actionlint@v1
+        env:
+          SHELLCHECK_OPTS: "-e SC2086 -e SC2129"
         with:
           level: warning
           fail_level: error

--- a/.github/workflows/new-release.yaml
+++ b/.github/workflows/new-release.yaml
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -58,6 +58,11 @@ on:
         default: "output"
         type: string
         description: Directory with the artifacts to upload
+      repositories:
+        required: false
+        type: string
+        default: ""
+        description: Comma or newline-separated list of repositories to grant access to during the golang build.
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -83,11 +88,29 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request }}
     steps:
+      - name: Prepare repositories list
+        id: prepare
+        run: |
+          repos="${{ inputs.repositories }}"
+          current_repo="${GITHUB_REPOSITORY#*/}"
+
+          # If inputs.repositories is empty, just use current repo
+          if [ -z "$repos" ]; then
+            repos="$current_repo"
+          else
+            repos="$repos,$current_repo"
+          fi
+
+          # Convert CSV to newline-separated list and deduplicate
+          echo "repositories<<EOF" >> $GITHUB_OUTPUT
+          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
+          repositories: ${{ steps.prepare.outputs.repositories }}
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -117,11 +140,29 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
+      - name: Prepare repositories list
+        id: prepare
+        run: |
+          repos="${{ inputs.repositories }}"
+          current_repo="${GITHUB_REPOSITORY#*/}"
+
+          # If inputs.repositories is empty, just use current repo
+          if [ -z "$repos" ]; then
+            repos="$current_repo"
+          else
+            repos="$repos,$current_repo"
+          fi
+
+          # Convert CSV to newline-separated list and deduplicate
+          echo "repositories<<EOF" >> $GITHUB_OUTPUT
+          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
+          repositories: ${{ steps.prepare.outputs.repositories }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -83,11 +83,11 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request }}
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -117,11 +117,11 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -88,29 +88,12 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request }}
     steps:
-      - name: Prepare repositories list
-        id: prepare
-        run: |
-          repos="${{ inputs.repositories }}"
-          current_repo="${GITHUB_REPOSITORY#*/}"
-
-          # If inputs.repositories is empty, just use current repo
-          if [ -z "$repos" ]; then
-            repos="$current_repo"
-          else
-            repos="$repos,$current_repo"
-          fi
-
-          # Convert CSV to newline-separated list and deduplicate
-          echo "repositories<<EOF" >> $GITHUB_OUTPUT
-          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ steps.prepare.outputs.repositories }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
       - uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -140,29 +123,12 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.files_changed == 'true' }}
     steps:
-      - name: Prepare repositories list
-        id: prepare
-        run: |
-          repos="${{ inputs.repositories }}"
-          current_repo="${GITHUB_REPOSITORY#*/}"
-
-          # If inputs.repositories is empty, just use current repo
-          if [ -z "$repos" ]; then
-            repos="$current_repo"
-          else
-            repos="$repos,$current_repo"
-          fi
-
-          # Convert CSV to newline-separated list and deduplicate
-          echo "repositories<<EOF" >> $GITHUB_OUTPUT
-          echo "$repos" | tr ',' '\n' | sort -u >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
-          repositories: ${{ steps.prepare.outputs.repositories }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -77,11 +77,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ ( github.event_name == 'pull_request' && needs.check_reviews.outputs.reviews == 'APPROVED') || github.event.review.state == 'approved' || startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_SECRET }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
       - uses: actions/checkout@v5
         if: ${{ startsWith(github.ref, 'refs/tags/') == false }}
         with:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,11 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2025-10-01
+## 0.0.3-dev - 2025-10-03
 
 ### Features
 
+- workflows: use official action to create github app tokens and support
+  additional repositories scoping (PR #207 by @chicco785)
 - python workflow: load python version from `pyproject.yaml` (PR #202 by
   @chicco785)
 - Add linter for github actions (PR #193 by @chicco785)


### PR DESCRIPTION
## Description

This PR modifies workflows to use official action to create github app tokens and support additional repositories scoping. The additional scoping is required for actions that import content from other private repositories that the current one. For example in the golang workflow, when not using vendoring.

## Changes Made

* use official action to create github app tokens
* support additional repositories scoping

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [ ] I have added appropriate documentation or updated existing documentation.
