### PR TITLE
python workflow: fix missing registry login to fetch private images

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -141,6 +141,13 @@ jobs:
           private-key: ${{ secrets.APP_SECRET }}
           repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
           permission-contents: read
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        # we log in the registry to code check also images
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -197,14 +204,6 @@ jobs:
           name: artefacts
           path: ${{ inputs.upload-artefacts-dir }}
           if-no-files-found: error
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        if: ${{ inputs.code-scan }}
-        # we log in the registry to code check also images
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud Code Scan
         if: ${{ inputs.code-scan }}
         uses: SonarSource/sonarqube-scan-action@v7.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,6 +54,8 @@
 
 ### Bug Fixes
 
+- python workflow: fix missing registry login to fetch private images (PR #281
+  by @chicco785)
 - Fix DVC version 3.66.1 (PR #278 by @cosimomeli)
 - Minor fixes: python / auto-approve wf (PR #272 by @chicco785)
 - markdown: Enable Corepack for modern package managers (PR #271 by @chicco785)
@@ -94,11 +96,11 @@
 
 ### Dependencies
 
+- Bump DavidAnson/markdownlint-cli2-action from 22 to 23 (PR #275 by
+  @dependabot[bot])
 - Bump actions/download-artifact from 4 to 8 (PR #274 by @dependabot[bot])
 - Bump actions/github-script from 7 to 8 (PR #276 by @dependabot[bot])
 - Support dvc[s3]==3.67.0 (PR #277 by @chicco785)
-- Bump DavidAnson/markdownlint-cli2-action from 22 to 23 (PR #275 by
-  @dependabot[bot])
 - Bump EndBug/add-and-commit from 9 to 10 (PR #264 by @dependabot[bot])
 - Bump dawidd6/action-download-artifact from 18 to 19 (PR #265 by
   @dependabot[bot])


### PR DESCRIPTION
## Description

This PR fix the container registry authentication bug in the python workflow. The issu prevented to pull zaphiro technologies private images.

## Changes Made

- Move registry authentication at the beginning of the workflow, remove the flag related to vulnerability.

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on cim-manager (https://github.com/zaphiro-technologies/cim-manager/pull/216)
- [ ] I have added appropriate documentation or updated existing documentation.
