### PR TITLE
docker wf: support login to docker hub to retrieve dhi.io images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -71,11 +71,6 @@ on:
         type: string
         default: ""
         description: Comma or newline-separated list of additional repositories needed for Docker build (e.g., private dependencies)
-      enable-dhi:
-        required: false
-        type: boolean
-        default: false
-        description: Login to Docker Hub before build to pull authenticated DHI base images
 
 jobs:
   check:
@@ -89,6 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
+    env:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/create-github-app-token@v3
         id: generate-token
@@ -162,22 +160,18 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Validate Docker Hub credentials for DHI
-        if: ${{ inputs.enable-dhi }}
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Validate Docker Hub credentials
         run: |
-          if [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASSWORD" ]; then
-            echo "enable-dhi requires DOCKER_USER and DOCKER_PASSWORD secrets" >&2
+          if { [ -n "$DOCKER_USER" ] && [ -z "$DOCKER_PASSWORD" ]; } || { [ -z "$DOCKER_USER" ] && [ -n "$DOCKER_PASSWORD" ]; }; then
+            echo "DOCKER_USER and DOCKER_PASSWORD must be provided together" >&2
             exit 1
           fi
       - name: Login to Docker Hub
-        if: ${{ inputs.enable-dhi }}
+        if: env.DOCKER_USER != '' && env.DOCKER_PASSWORD != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,6 +23,10 @@ on:
     secrets:
       BUILD_SECRET:
         required: false
+      DOCKER_USER:
+        required: false
+      DOCKER_PASSWORD:
+        required: false
       APP_ID:
         required: true
       APP_SECRET:
@@ -67,6 +71,11 @@ on:
         type: string
         default: ""
         description: Comma or newline-separated list of additional repositories needed for Docker build (e.g., private dependencies)
+      enable-dhi:
+        required: false
+        type: boolean
+        default: false
+        description: Login to Docker Hub before build to pull authenticated DHI base images
 
 jobs:
   check:
@@ -153,6 +162,22 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      - name: Validate Docker Hub credentials for DHI
+        if: ${{ inputs.enable-dhi }}
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          if [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASSWORD" ]; then
+            echo "enable-dhi requires DOCKER_USER and DOCKER_PASSWORD secrets" >&2
+            exit 1
+          fi
+      - name: Login to Docker Hub
+        if: ${{ inputs.enable-dhi }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/README.MD
+++ b/README.MD
@@ -38,10 +38,9 @@ The repository includes:
 - [`deployment`](.github/workflows/deployment.yaml): commit a container image
   tag in the k8s-deployments repository.
 - [`docker`](.github/workflows/docker.yaml): build and push Docker images and
-  scans for vulnerabilities. Supports optional Docker Hub login for builds
-  that need authenticated base image pulls from Docker Hub; callers can pass
-  `DOCKER_USER` and `DOCKER_PASSWORD` secrets, which must be provided
-  together.
+  scans for vulnerabilities. Supports optional Docker Hub login for builds that
+  need authenticated base image pulls from Docker Hub; callers can pass
+  `DOCKER_USER` and `DOCKER_PASSWORD` secrets, which must be provided together.
 - [`golang`](.github/workflows/golang.yaml): lint, test and benchmark Go
   Applications. The workflow includes authentication to GitHub Container
   Registry in case tests rely on private images. The workflow also scans for

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,10 @@ The repository includes:
 - [`deployment`](.github/workflows/deployment.yaml): commit a container image
   tag in the k8s-deployments repository.
 - [`docker`](.github/workflows/docker.yaml): build and push Docker images and
-  scans for vulnerabilities.
+  scans for vulnerabilities. Supports optional Docker Hub login through
+  `enable-dhi: true` for builds that need authenticated base image pulls from
+  Docker Hub; callers must then pass `DOCKER_USER` and `DOCKER_PASSWORD`
+  secrets.
 - [`golang`](.github/workflows/golang.yaml): lint, test and benchmark Go
   Applications. The workflow includes authentication to GitHub Container
   Registry in case tests rely on private images. The workflow also scans for

--- a/README.MD
+++ b/README.MD
@@ -38,10 +38,10 @@ The repository includes:
 - [`deployment`](.github/workflows/deployment.yaml): commit a container image
   tag in the k8s-deployments repository.
 - [`docker`](.github/workflows/docker.yaml): build and push Docker images and
-  scans for vulnerabilities. Supports optional Docker Hub login through
-  `enable-dhi: true` for builds that need authenticated base image pulls from
-  Docker Hub; callers must then pass `DOCKER_USER` and `DOCKER_PASSWORD`
-  secrets.
+  scans for vulnerabilities. Supports optional Docker Hub login for builds
+  that need authenticated base image pulls from Docker Hub; callers can pass
+  `DOCKER_USER` and `DOCKER_PASSWORD` secrets, which must be provided
+  together.
 - [`golang`](.github/workflows/golang.yaml): lint, test and benchmark Go
   Applications. The workflow includes authentication to GitHub Container
   Registry in case tests rely on private images. The workflow also scans for

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,11 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2026-04-15
+## 0.0.3-dev - 2026-04-29
 
 ### Features
 
+- docker wf: support login to docker hub to retrieve dhi.io images (PR #286 by
+  @chicco785)
 - python workflow: ensure python version consistency (PR #246 by @chicco785)
 - add-to-project wf: add stale issues bot (PR #231 by @chicco785)
 - support ALL for deployment (PR #222 by @chicco785)
@@ -96,6 +98,7 @@
 
 ### Dependencies
 
+- Bump oras-project/setup-oras from 1 to 2 (PR #280 by @dependabot[bot])
 - Bump SonarSource/sonarqube-scan-action from 7.0.0 to 7.1.0 (PR #279 by
   @dependabot[bot])
 - Bump stefanzweifel/git-auto-commit-action from 5 to 7 (PR #273 by
@@ -103,7 +106,6 @@
 - Bump DavidAnson/markdownlint-cli2-action from 22 to 23 (PR #275 by
   @dependabot[bot])
 - Bump actions/download-artifact from 4 to 8 (PR #274 by @dependabot[bot])
-- Bump oras-project/setup-oras from 1 to 2 (PR #280 by @dependabot[bot])
 - Bump actions/github-script from 7 to 8 (PR #276 by @dependabot[bot])
 - Support dvc[s3]==3.67.0 (PR #277 by @chicco785)
 - Bump EndBug/add-and-commit from 9 to 10 (PR #264 by @dependabot[bot])


### PR DESCRIPTION
## Description

This PR updates the docker workflow to support pulling dhi.io images.

## Changes Made

- Add user / pwd check to login in dockerhub

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on [report-generator](https://github.com/zaphiro-technologies/report-generator/pull/233)
- [x] I have added appropriate documentation or updated existing documentation.
