### PR TITLE
approve and merge wf: pr were failing checks are not required should be merged

### DIFF
--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -61,8 +61,8 @@ jobs:
 
             if echo "$labels" | grep -q "auto-approved"; then
               mergeable_state=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
-              if [ "$mergeable_state" = "DIRTY" ]; then
-                echo "❌ Skipping PR #$number: merge conflicts detected"
+              if echo "$mergeable_state" | grep -Eiq 'BLOCKED|BEHIND|DIRTY|DRAFT|HAS_HOOKS|UNKNOWN'; then
+                echo "❌ Skipping PR #$number: PR is not mergeable yet ($mergeable_state)"
                 continue
               else
                 echo "✅ PR #$number is up to date and already approved."
@@ -74,12 +74,10 @@ jobs:
             fi
 
             echo "🔍 Checking CI status for PR #$number..."
-            commit_sha=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq '.headRefOid')
+            mergeable_state=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
 
-            checks_state=$(gh api repos/$GITHUB_REPOSITORY/commits/$commit_sha/check-runs --jq '[.check_runs[].conclusion] | unique | join(",")')
-
-            if echo "$checks_state" | grep -Eiq 'failure|timed_out|action_required'; then
-              echo "❌ Skipping PR #$number: one or more checks failed ($checks_state)"
+            if echo "$mergeable_state" | grep -Eiq 'BLOCKED|BEHIND|DIRTY|DRAFT|HAS_HOOKS|UNKNOWN'; then
+              echo "❌ Skipping PR #$number: PR is not mergeable yet ($mergeable_state)"
               continue
             fi
 

--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -61,10 +61,32 @@ jobs:
 
             if echo "$labels" | grep -q "auto-approved"; then
               mergeable_state=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
-              if echo "$mergeable_state" | grep -Eiq 'BLOCKED|BEHIND|DIRTY|DRAFT|HAS_HOOKS|UNKNOWN'; then
+              if echo "$mergeable_state" | grep -Eiq 'BEHIND|DIRTY|DRAFT'; then
                 echo "❌ Skipping PR #$number: PR is not mergeable yet ($mergeable_state)"
                 continue
               else
+                set +e
+                required_checks=$(gh pr checks "$number" --repo "$GITHUB_REPOSITORY" --required --json bucket,name,state 2>/dev/null)
+                checks_exit_code=$?
+                set -e
+
+                if [ "$checks_exit_code" -ne 0 ] && [ "$checks_exit_code" -ne 8 ]; then
+                  echo "❌ Skipping PR #$number: unable to inspect required checks"
+                  continue
+                fi
+
+                failed_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name] | join(", ")')
+                pending_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")')
+
+                if [ -n "$failed_required_checks" ]; then
+                  echo "❌ Skipping PR #$number: required checks failed ($failed_required_checks)"
+                  continue
+                fi
+
+                if [ -n "$pending_required_checks" ]; then
+                  echo "⏳ PR #$number still has required checks in progress ($pending_required_checks). Enabling auto-merge."
+                fi
+
                 echo "✅ PR #$number is up to date and already approved."
                 echo "🔀 Merging PR #$number"
                 gh pr merge "$number" --repo "$GITHUB_REPOSITORY" --squash --auto
@@ -76,9 +98,31 @@ jobs:
             echo "🔍 Checking CI status for PR #$number..."
             mergeable_state=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
 
-            if echo "$mergeable_state" | grep -Eiq 'BLOCKED|BEHIND|DIRTY|DRAFT|HAS_HOOKS|UNKNOWN'; then
+            if echo "$mergeable_state" | grep -Eiq 'BEHIND|DIRTY|DRAFT'; then
               echo "❌ Skipping PR #$number: PR is not mergeable yet ($mergeable_state)"
               continue
+            fi
+
+            set +e
+            required_checks=$(gh pr checks "$number" --repo "$GITHUB_REPOSITORY" --required --json bucket,name,state 2>/dev/null)
+            checks_exit_code=$?
+            set -e
+
+            if [ "$checks_exit_code" -ne 0 ] && [ "$checks_exit_code" -ne 8 ]; then
+              echo "❌ Skipping PR #$number: unable to inspect required checks"
+              continue
+            fi
+
+            failed_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name] | join(", ")')
+            pending_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")')
+
+            if [ -n "$failed_required_checks" ]; then
+              echo "❌ Skipping PR #$number: required checks failed ($failed_required_checks)"
+              continue
+            fi
+
+            if [ -n "$pending_required_checks" ]; then
+              echo "⏳ PR #$number still has required checks in progress ($pending_required_checks). Enabling auto-merge."
             fi
 
             echo "🚀 Approving and merging PR #$number"

--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -49,6 +49,46 @@ jobs:
             echo "Label auto-approved already exists. Skipping creation."
           fi
 
+          check_pr_readiness() {
+            local pr_number="$1"
+            local mergeable_state
+            local required_checks
+            local checks_exit_code
+            local failed_required_checks
+            local pending_required_checks
+
+            mergeable_state=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
+            if echo "$mergeable_state" | grep -Eiq 'BEHIND|DIRTY|DRAFT'; then
+              echo "❌ Skipping PR #$pr_number: PR is not mergeable yet ($mergeable_state)"
+              return 1
+            fi
+
+            set +e
+            required_checks=$(gh pr checks "$pr_number" --repo "$GITHUB_REPOSITORY" --required --json bucket,name,state 2>/dev/null)
+            checks_exit_code=$?
+            set -e
+
+            if [ "$checks_exit_code" -ne 0 ] && [ "$checks_exit_code" -ne 8 ]; then
+              echo "❌ Skipping PR #$pr_number: unable to inspect required checks"
+              return 1
+            fi
+
+            failed_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name] | join(", ")')
+            pending_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")')
+
+            if [ -n "$failed_required_checks" ]; then
+              echo "❌ Skipping PR #$pr_number: required checks failed ($failed_required_checks)"
+              return 1
+            fi
+
+            if [ -n "$pending_required_checks" ]; then
+              echo "⏳ Skipping PR #$pr_number: required checks still in progress ($pending_required_checks)"
+              return 1
+            fi
+
+            return 0
+          }
+
           echo "Fetching open Dependabot PRs older than 3 days and newer than 30 days ..."
 
           gh pr list --repo "$GITHUB_REPOSITORY" --author app/dependabot --state open --json number,createdAt,title,labels,headRefName --jq '.[] | select((.createdAt | fromdateiso8601) < (now - 259200))' | jq -c '.' | while IFS= read -r pr; do
@@ -60,70 +100,19 @@ jobs:
             echo "👉 Processing PR #$number: $title"
 
             if echo "$labels" | grep -q "auto-approved"; then
-              mergeable_state=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
-              if echo "$mergeable_state" | grep -Eiq 'BEHIND|DIRTY|DRAFT'; then
-                echo "❌ Skipping PR #$number: PR is not mergeable yet ($mergeable_state)"
-                continue
-              else
-                set +e
-                required_checks=$(gh pr checks "$number" --repo "$GITHUB_REPOSITORY" --required --json bucket,name,state 2>/dev/null)
-                checks_exit_code=$?
-                set -e
-
-                if [ "$checks_exit_code" -ne 0 ] && [ "$checks_exit_code" -ne 8 ]; then
-                  echo "❌ Skipping PR #$number: unable to inspect required checks"
-                  continue
-                fi
-
-                failed_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name] | join(", ")')
-                pending_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")')
-
-                if [ -n "$failed_required_checks" ]; then
-                  echo "❌ Skipping PR #$number: required checks failed ($failed_required_checks)"
-                  continue
-                fi
-
-                if [ -n "$pending_required_checks" ]; then
-                  echo "⏳ Skipping PR #$number: required checks still in progress ($pending_required_checks)"
-                  continue
-                fi
-
-                echo "✅ PR #$number is up to date and already approved."
-                echo "🔀 Merging PR #$number"
-                gh pr merge "$number" --repo "$GITHUB_REPOSITORY" --squash --auto
-                echo "✅ Done with PR #$number"
+              if ! check_pr_readiness "$number"; then
                 continue
               fi
+
+              echo "✅ PR #$number is up to date and already approved."
+              echo "🔀 Merging PR #$number"
+              gh pr merge "$number" --repo "$GITHUB_REPOSITORY" --squash --auto
+              echo "✅ Done with PR #$number"
+              continue
             fi
 
             echo "🔍 Checking CI status for PR #$number..."
-            mergeable_state=$(gh pr view "$number" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus --jq '.mergeStateStatus')
-
-            if echo "$mergeable_state" | grep -Eiq 'BEHIND|DIRTY|DRAFT'; then
-              echo "❌ Skipping PR #$number: PR is not mergeable yet ($mergeable_state)"
-              continue
-            fi
-
-            set +e
-            required_checks=$(gh pr checks "$number" --repo "$GITHUB_REPOSITORY" --required --json bucket,name,state 2>/dev/null)
-            checks_exit_code=$?
-            set -e
-
-            if [ "$checks_exit_code" -ne 0 ] && [ "$checks_exit_code" -ne 8 ]; then
-              echo "❌ Skipping PR #$number: unable to inspect required checks"
-              continue
-            fi
-
-            failed_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "fail" or .bucket == "cancel") | .name] | join(", ")')
-            pending_required_checks=$(echo "${required_checks:-[]}" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")')
-
-            if [ -n "$failed_required_checks" ]; then
-              echo "❌ Skipping PR #$number: required checks failed ($failed_required_checks)"
-              continue
-            fi
-
-            if [ -n "$pending_required_checks" ]; then
-              echo "⏳ Skipping PR #$number: required checks still in progress ($pending_required_checks)"
+            if ! check_pr_readiness "$number"; then
               continue
             fi
 

--- a/.github/workflows/approve-and-merge.yaml
+++ b/.github/workflows/approve-and-merge.yaml
@@ -84,7 +84,8 @@ jobs:
                 fi
 
                 if [ -n "$pending_required_checks" ]; then
-                  echo "⏳ PR #$number still has required checks in progress ($pending_required_checks). Enabling auto-merge."
+                  echo "⏳ Skipping PR #$number: required checks still in progress ($pending_required_checks)"
+                  continue
                 fi
 
                 echo "✅ PR #$number is up to date and already approved."
@@ -122,7 +123,8 @@ jobs:
             fi
 
             if [ -n "$pending_required_checks" ]; then
-              echo "⏳ PR #$number still has required checks in progress ($pending_required_checks). Enabling auto-merge."
+              echo "⏳ Skipping PR #$number: required checks still in progress ($pending_required_checks)"
+              continue
             fi
 
             echo "🚀 Approving and merging PR #$number"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2026-05-08
+## 0.0.3-dev - 2026-05-19
 
 ### Features
 
@@ -58,6 +58,8 @@
 
 ### Bug Fixes
 
+- approve and merge wf: pr were failing checks are not required should be merged
+  (PR #292 by @chicco785)
 - python workflow: fix missing registry login to fetch private images (PR #281
   by @chicco785)
 - Fix DVC version 3.66.1 (PR #278 by @cosimomeli)
@@ -100,11 +102,11 @@
 
 ### Dependencies
 
+- Bump actions/add-to-project from 1.0.2 to 2.0.0 (PR #288 by @dependabot[bot])
 - Bump SonarSource/sonarqube-scan-action from 7.1.0 to 8.0.0 (PR #289 by
   @dependabot[bot])
 - Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0 (PR #285 by
   @dependabot[bot])
-- Bump actions/add-to-project from 1.0.2 to 2.0.0 (PR #288 by @dependabot[bot])
 - Bump actions/github-script from 8 to 9 (PR #283 by @dependabot[bot])
 - Bump oras-project/setup-oras from 1 to 2 (PR #280 by @dependabot[bot])
 - Bump SonarSource/sonarqube-scan-action from 7.0.0 to 7.1.0 (PR #279 by


### PR DESCRIPTION
## Description

This PR fixes the approve and merge wf, allowing auto approve and merge pr were failing checks are not required. Currently, if two or more PRs are opened in parallel to fix a vulnerability, both will fail (since there are more than 1 vulnerability and hence the check fails).

## Changes Made

- Check "mergeable" status of the PR instead of results of checks.

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on [data-management-api](https://github.com/zaphiro-technologies/data-management-api/actions/runs/26040028660/job/76548747053#step:3:111)
- [ ] I have added appropriate documentation or updated existing documentation.
