### PR TITLE
Use Linkspector 1.4.1

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -192,7 +192,7 @@ jobs:
         run: |
           mkdir -p "$HOME/reviewdog-bin"
       - name: Check links
-        uses: umbrelladocs/action-linkspector@v1.5.1
+        uses: umbrelladocs/action-linkspector@v1.4.1
         with:
           filter_mode: nofilter
           reporter: github-pr-review

--- a/README.MD
+++ b/README.MD
@@ -161,3 +161,7 @@ documentation.
 [.github]: https://github.com/zaphiro-technologies/.github
 [starter-workflows]:
   https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization
+
+## Issues
+
+Linkspector 1.5.x is broken.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2026-06-01
+## 0.0.3-dev - 2026-06-02
 
 ### Features
 
@@ -58,6 +58,7 @@
 
 ### Bug Fixes
 
+- Use Linkspector 1.4.1 (PR #296 by @cosimomeli)
 - approve and merge wf: pr were failing checks are not required should be merged
   (PR #292 by @chicco785)
 - python workflow: fix missing registry login to fetch private images (PR #281


### PR DESCRIPTION
## Description

Fix broken linkspector 1.5.*

## Changes Made

Replace linkspector 1.5.* with 1.4.1

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [ ] I have added appropriate documentation or updated existing documentation.
