### PR TITLE
markdown wf: fix chrome for puppeteer

### DIFF
--- a/.github/config/.linkspector.yml
+++ b/.github/config/.linkspector.yml
@@ -8,7 +8,7 @@ aliveStatusCodes:
   - 204
   - 206
   - 429
-ignorePatterns:
-  - pattern: "^https://localhost"
-  - pattern: "^https://github.com/orgs/zaphiro-technologies/"
-  - pattern: "^https://github.com/zaphiro-technologies/"
+# ignorePatterns:
+#   - pattern: "^https://localhost"
+#   - pattern: "^https://github.com/orgs/zaphiro-technologies/"
+#   - pattern: "^https://github.com/zaphiro-technologies/"

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -51,7 +51,7 @@ on:
           #RELEASE_NOTES.md
 jobs:
   changes:
-    if: ${{ github.event.pull_request.draft == false }}
+    #if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     outputs:
       files_changed: ${{ steps.filter.outputs.markdown == 'true' || steps.filter.outputs.scripts == 'true' }}
@@ -117,7 +117,7 @@ jobs:
           reporter: github-pr-review
   markdown:
     needs: changes
-    if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request.draft == false }}
+    #if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -204,3 +204,4 @@ jobs:
           reporter: github-pr-review
           config_file: ${{ inputs.config-links-path || '.github/config/.linkspector.yml' }}
           fail_level: any
+          show_stats: true

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -191,10 +191,14 @@ jobs:
       - name: Prepare reviewdog cache path
         run: |
           mkdir -p "$HOME/reviewdog-bin"
-      - name: Install Chrome for Puppeteer
-        run: npx puppeteer browsers install chrome
+      - name: Install Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
       - name: Check links
         uses: umbrelladocs/action-linkspector@v1.5.2
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
         with:
           filter_mode: nofilter
           reporter: github-pr-review

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -51,7 +51,7 @@ on:
           #RELEASE_NOTES.md
 jobs:
   changes:
-    #if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     outputs:
       files_changed: ${{ steps.filter.outputs.markdown == 'true' || steps.filter.outputs.scripts == 'true' }}
@@ -117,7 +117,7 @@ jobs:
           reporter: github-pr-review
   markdown:
     needs: changes
-    #if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request.draft == false }}
+    if: ${{ needs.changes.outputs.files_changed == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3

--- a/README.MD
+++ b/README.MD
@@ -164,4 +164,4 @@ documentation.
 
 ## Issues
 
-Linkspector 1.5.x is broken, so force manual install of Chrome for Puppeteer
+Linkspector 1.5.x is broken, so force manual install of Chrome for Puppeteer.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -105,6 +105,7 @@
 
 ### Dependencies
 
+- Bump actions/checkout from 6.0.2 to 6.0.3 (PR #301 by @dependabot[bot])
 - Bump actions/checkout from 6 to 6.0.2 (PR #298 by @dependabot[bot])
 - Bump umbrelladocs/action-linkspector from 1.4.1 to 1.5.2 (PR #297 by
   @dependabot[bot])

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2026-06-04
+## 0.0.3-dev - 2026-06-09
 
 ### Features
 
@@ -58,6 +58,7 @@
 
 ### Bug Fixes
 
+- markdown wf: fix chrome for puppeteer (PR #299 by @chicco785)
 - Use Linkspector 1.4.1 (PR #296 by @cosimomeli)
 - approve and merge wf: pr were failing checks are not required should be merged
   (PR #292 by @chicco785)
@@ -104,6 +105,7 @@
 
 ### Dependencies
 
+- Bump actions/checkout from 6 to 6.0.2 (PR #298 by @dependabot[bot])
 - Bump umbrelladocs/action-linkspector from 1.4.1 to 1.5.2 (PR #297 by
   @dependabot[bot])
 - Bump umbrelladocs/action-linkspector from 1 to 1.5.1 (PR #295 by

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2026-06-09
+## 0.0.3-dev - 2026-06-10
 
 ### Features
 


### PR DESCRIPTION
## Description

This PR fixes the installation of chrome used by puppeteer for links review.

## Changes Made

- Install chrome with apt
- Expose linkspector stats

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on [architecture](https://github.com/zaphiro-technologies/architecture/actions/runs/26952829098/job/79522191511?pr=257#step:13:307)
- [ ] I have added appropriate documentation or updated existing documentation.
