### PR TITLE
js & docker workflow:  allow to use private repos during lint & build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -189,6 +189,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            GH_TOKEN=${{ steps.generate-token.outputs.token }}
           build-args: |
             GIT_REV=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.revision']}}
             GIT_VERSION=${{fromJson(steps.meta.outputs.json).labels['org.opencontainers.image.version']}}

--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -87,6 +87,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}
+          repositories: ${{ github.event.repository.name }}${{ inputs.repositories && format(',{0}', inputs.repositories) || '' }}
           permission-contents: write
       - uses: actions/checkout@v6.0.3
         with:

--- a/README.MD
+++ b/README.MD
@@ -46,11 +46,10 @@ The repository includes:
   scans for vulnerabilities. Supports optional Docker Hub login for builds that
   need authenticated base image pulls from Docker Hub; callers can pass
   `DOCKER_USER` and `DOCKER_PASSWORD` secrets, which must be provided together.
-  For private GitHub git dependencies during `docker build`, pass the
-  additional private repositories via the `repositories` input so the generated
-  GitHub App token can access them, then consume the forwarded BuildKit secret
-  (`GH_TOKEN`) in the Dockerfile. The Docker build image must also include the
-  `git` binary.
+  For private GitHub git dependencies during `docker build`, pass the additional
+  private repositories via the `repositories` input so the generated GitHub App
+  token can access them, then consume the forwarded BuildKit secret (`GH_TOKEN`)
+  in the Dockerfile. The Docker build image must also include the `git` binary.
 - [`golang`](.github/workflows/golang.yaml): lint, test and benchmark Go
   Applications. The workflow includes authentication to GitHub Container
   Registry in case tests rely on private images. The workflow also scans for

--- a/README.MD
+++ b/README.MD
@@ -46,6 +46,11 @@ The repository includes:
   scans for vulnerabilities. Supports optional Docker Hub login for builds that
   need authenticated base image pulls from Docker Hub; callers can pass
   `DOCKER_USER` and `DOCKER_PASSWORD` secrets, which must be provided together.
+  For private GitHub git dependencies during `docker build`, pass the
+  additional private repositories via the `repositories` input so the generated
+  GitHub App token can access them, then consume the forwarded BuildKit secret
+  (`GH_TOKEN`) in the Dockerfile. The Docker build image must also include the
+  `git` binary.
 - [`golang`](.github/workflows/golang.yaml): lint, test and benchmark Go
   Applications. The workflow includes authentication to GitHub Container
   Registry in case tests rely on private images. The workflow also scans for

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,11 @@
 # GitHub Workflows Release Notes
 
-## 0.0.3-dev - 2026-06-10
+## 0.0.3-dev - 2026-06-19
 
 ### Features
 
+- js & docker workflow: allow to use private repos during lint & build (PR #304
+  by @chicco785)
 - Support Corporate deployments (PR #300 by @cosimomeli)
 - js workflow: shared workflow for javascript builds based on yarn2 (PR #287 by
   @chicco785)


### PR DESCRIPTION
## Description

This PR add allow lint job in js workflow to access input `repositories` and pass token to docker workflow so that private repositories can be read for build.

## Changes Made

- js workflow: allow lint to access input `repositories` (required to install private packages)
- docker workflow: pass action token to read `repositories` (required to install private packages)

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on [documentation](https://github.com/zaphiro-technologies/documentation/actions/runs/27782843883/job/82211893558)
- [ ] I have added appropriate documentation or updated existing documentation.
