### PR TITLE
deployment: update tag only where the app entry already exists

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -197,6 +197,12 @@ jobs:
               for part in $(echo "${{ inputs.app-name }}" | tr '.' '\n'); do
                   app_path="${app_path}[\"$part\"]"
               done
+
+              if [ "$(yq "$app_path != null" "$cluster/values-platforms.yaml")" != "true" ]; then
+                echo "Skipping platform $platform: application ${{ inputs.app-name }} is not configured"
+                continue
+              fi
+
               yq -i "$app_path.image.tag = \"${IMAGE_TAG}\"" \
                   "$cluster/values-platforms.yaml"
             done


### PR DESCRIPTION
## Description

deployment: update tag only where the app entry already exists

## Changes Made

- deployment: update tag only where the app entry already exists

## Related Issues


## Checklist

- [ ] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [ ] I have added appropriate documentation or updated existing documentation.
